### PR TITLE
docs: Add GitHub wiki documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install cconsent
 
 ```html
 <link rel="stylesheet" href="https://unpkg.com/cconsent/dist/style.css">
-<script src="https://unpkg.com/cconsent/dist/cookie-consent.umd.js"></script>
+<script src="https://unpkg.com/cconsent/dist/index.umd.js"></script>
 ```
 
 ## 🚀 Quick Start
@@ -146,4 +146,4 @@ Contributions are welcome! Please read our contributing guidelines before submit
 
 ## 📄 License
 
-MIT © [Your Name]
+MIT © pxdsgnco

--- a/README.md
+++ b/README.md
@@ -1,33 +1,24 @@
-# Cookie Consent Dialog
+# cconsent
 
-A lightweight, GDPR-compliant cookie consent dialog built with vanilla HTML, CSS, and JavaScript. Now with Google Consent Mode v2, geolocation-based consent, and framework adapters.
+A lightweight, GDPR-compliant cookie consent library with Google Consent Mode v2, geolocation-based consent, and framework adapters for React, Vue, and Svelte.
 
-## Features
+[![npm version](https://img.shields.io/npm/v/cconsent.svg)](https://www.npmjs.com/package/cconsent)
+[![Bundle Size](https://img.shields.io/bundlephobia/minzip/cconsent)](https://bundlephobia.com/package/cconsent)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-- Clean, modern dark theme design
-- **5-category consent model**: Necessary, Functional, Preferences, Analytics, Marketing
-- Google Consent Mode v2 integration
-- Geolocation-based consent modes (GDPR, CCPA, LGPD)
-- Automatic script and iframe blocking with MutationObserver
-- Multi-category support with OR logic and negation
-- Customizable settings panel with toggle switches
-- Fully customizable text content
-- Flexible storage: localStorage or cookies
-- Optional Base64 encoding for consent data
-- Consent ID generation for server-side tracking
-- Accessible (WCAG 2.1 AA compliant)
-- Responsive design with mobile bottom sheet
-- Framework adapters for React, Vue, and Svelte
-- TypeScript support with full type definitions
+## ✨ Features
 
-## Installation
+- **5-Category Consent Model** — Necessary, Functional, Preferences, Analytics, Marketing
+- **Google Consent Mode v2** — Native GA4 and Google Ads integration
+- **Geolocation Detection** — Auto-detect GDPR, CCPA, LGPD regions
+- **Script Blocking** — Automatic blocking via `data-cookie-category` attributes
+- **Framework Adapters** — React, Vue 3, and Svelte support
+- **Accessible** — WCAG 2.1 AA compliant with keyboard navigation
+- **Mobile-First** — Bottom sheet pattern with swipe gestures
+- **Zero Dependencies** — Vanilla JS, < 15KB gzipped
+- **TypeScript Support** — Full type definitions included
 
-### Browser (CDN)
-
-```html
-<link rel="stylesheet" href="css/cookie-consent.css">
-<script src="js/cookie-consent.js"></script>
-```
+## 📦 Installation
 
 ### NPM
 
@@ -35,19 +26,21 @@ A lightweight, GDPR-compliant cookie consent dialog built with vanilla HTML, CSS
 npm install cconsent
 ```
 
+### CDN
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/cconsent/dist/style.css">
+<script src="https://unpkg.com/cconsent/dist/cookie-consent.umd.js"></script>
+```
+
+## 🚀 Quick Start
+
 ```javascript
 import CookieConsent from 'cconsent';
 import 'cconsent/style.css';
 
-const consent = new CookieConsent({ policyUrl: '/privacy' });
-consent.init();
-```
-
-## Quick Start
-
-```javascript
-const cookieConsent = new CookieConsent({
-  policyUrl: 'https://yoursite.com/cookie-policy',
+const consent = new CookieConsent({
+  policyUrl: '/cookie-policy',
   googleConsentMode: { enabled: true },
   floatingButton: { enabled: true },
   onAccept: (categories) => console.log('Accepted:', categories),
@@ -55,267 +48,20 @@ const cookieConsent = new CookieConsent({
   onSave: (categories) => console.log('Saved:', categories)
 });
 
-cookieConsent.init();
+consent.init();
 ```
 
-## Cookie Categories
-
-The 5-category model provides granular control over consent:
-
-| Category | Default | Toggleable | Description |
-|----------|---------|------------|-------------|
-| Necessary | ON | No | Required for security and basic functionality |
-| Functional | OFF | Yes | Enhanced features like live chat and videos |
-| Preferences | OFF | Yes | Remembers settings like language and theme |
-| Analytics | OFF | Yes | Site usage and performance tracking |
-| Marketing | OFF | Yes | Personalized ads and cross-site tracking |
-
-### Consent Object
-
-```javascript
-{
-  version: "2.0",
-  necessary: true,
-  functional: boolean,
-  preferences: boolean,
-  analytics: boolean,
-  marketing: boolean,
-  timestamp: string,
-  consentId: string  // Only if generateConsentId: true
-}
-```
-
-## Configuration
-
-### Constructor Options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `storageKey` | string | `'cookie_consent'` | Storage key name |
-| `storageMethod` | string | `'localStorage'` | `'localStorage'` or `'cookie'` |
-| `cookieOptions` | object | See below | Cookie configuration |
-| `encryption` | boolean | `false` | Enable Base64 encoding |
-| `generateConsentId` | boolean | `false` | Generate unique UUID |
-| `policyUrl` | string | `'#'` | Cookie policy URL |
-| `debug` | boolean | `false` | Enable debug mode |
-| `legacyMode` | boolean | `false` | Use 3-category callbacks |
-| `floatingButton` | object | See below | Floating button config |
-| `googleConsentMode` | object | See below | Google Consent Mode v2 |
-| `geo` | object | See below | Geolocation detection |
-| `content` | object | See below | UI text customization |
-| `onAccept` | function | `null` | Callback on accept all |
-| `onReject` | function | `null` | Callback on reject all |
-| `onSave` | function | `null` | Callback on save preferences |
-
-### Cookie Storage Options
-
-```javascript
-cookieOptions: {
-  sameSite: 'Strict',  // 'Strict', 'Lax', or 'None'
-  secure: true,
-  domain: null,
-  path: '/',
-  expires: 365  // Days
-}
-```
-
-## Google Consent Mode v2
-
-Integrate with Google Analytics 4 and Google Ads:
-
-```javascript
-const cookieConsent = new CookieConsent({
-  googleConsentMode: {
-    enabled: true,
-    waitForUpdate: 500,
-    mapping: {
-      analytics: ['analytics_storage'],
-      marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
-      functional: [],
-      preferences: []
-    },
-    adsDataRedaction: true,
-    urlPassthrough: false,
-    regionDefaults: {
-      'US': { ad_storage: 'granted', analytics_storage: 'granted' },
-      'EU': { ad_storage: 'denied', analytics_storage: 'denied' }
-    }
-  }
-});
-```
-
-### Consent Signals
-
-| Signal | Category | Description |
-|--------|----------|-------------|
-| `analytics_storage` | analytics | Google Analytics cookies |
-| `ad_storage` | marketing | Advertising cookies |
-| `ad_user_data` | marketing | User data for ads |
-| `ad_personalization` | marketing | Personalized advertising |
-
-### DataLayer Events
-
-When consent changes, an event is pushed to the dataLayer:
-
-```javascript
-{
-  event: 'cookie_consent_update',
-  cookie_consent: {
-    necessary: true,
-    functional: boolean,
-    preferences: boolean,
-    analytics: boolean,
-    marketing: boolean
-  }
-}
-```
-
-## Geolocation Detection
-
-Automatically adjust consent requirements based on user location:
-
-```javascript
-const cookieConsent = new CookieConsent({
-  geo: {
-    enabled: true,
-    method: 'timezone',  // 'timezone', 'api', or 'header'
-    apiEndpoint: null,   // For 'api' method
-    headerName: 'CF-IPCountry',  // For 'header' method
-    timeout: 500,
-    cache: true,
-    cacheDuration: 86400000,  // 24 hours
-    regions: {
-      gdpr: ['AT', 'BE', 'BG', ...],  // EU countries
-      ccpa: ['US-CA'],
-      lgpd: ['BR']
-    },
-    modeByRegion: {
-      gdpr: 'opt-in',   // Must consent before tracking
-      ccpa: 'opt-out',  // Can track until rejected
-      lgpd: 'opt-in',
-      default: 'none'   // No consent UI needed
-    }
-  }
-});
-```
-
-### Detection Methods
-
-| Method | Description |
-|--------|-------------|
-| `timezone` | Uses `Intl.DateTimeFormat` to detect country from timezone |
-| `api` | Calls external geolocation API endpoint |
-| `header` | Reads country from `<meta name="user-country">` tag |
-
-### CCPA Mode
-
-When `geo.modeByRegion.ccpa: 'opt-out'` is active, the reject button shows "Do Not Sell My Info" instead of "Reject All Cookies".
-
-## Script & Iframe Blocking
-
-### Basic Usage
+### Block Scripts Until Consent
 
 ```html
-<!-- Blocked until analytics consent -->
+<!-- Blocked until analytics consent is given -->
 <script data-cookie-category="analytics" src="https://analytics.example.com/script.js"></script>
 
-<!-- Blocked until marketing consent -->
+<!-- Blocked until marketing consent is given -->
 <iframe data-cookie-category="marketing" src="https://ads.example.com/widget"></iframe>
 ```
 
-### Multi-Category Support
-
-```html
-<!-- Allowed if EITHER analytics OR marketing is consented (OR logic) -->
-<script data-cookie-category="analytics marketing" src="script.js"></script>
-
-<!-- Allowed only if marketing is NOT consented (negation) -->
-<script data-cookie-category="!marketing" src="privacy-focused.js"></script>
-```
-
-### Dynamic Script Detection
-
-Scripts and iframes added dynamically via JavaScript are automatically detected and blocked using MutationObserver:
-
-```javascript
-// This script will be automatically blocked if analytics not consented
-const script = document.createElement('script');
-script.src = 'https://analytics.example.com/track.js';
-script.setAttribute('data-cookie-category', 'analytics');
-document.body.appendChild(script);
-```
-
-### Blocked Content Placeholders
-
-Blocked iframes display a placeholder with a "Change settings" link:
-
-```css
-.cc-blocked-placeholder {
-  /* Customizable via CSS variables */
-}
-```
-
-### Script Management API
-
-```javascript
-// Re-scan DOM for new scripts/iframes
-window.CookieConsent.scanScripts();
-
-// Check if an element would be allowed
-window.CookieConsent.wouldRunScript(element);
-
-// Get managed scripts info
-window.CookieConsent.getManagedScripts();
-// [{ src: "analytics.js", category: "analytics", status: "blocked" }]
-
-// Get managed iframes info
-window.CookieConsent.getManagedIframes();
-// [{ src: "widget.html", category: "marketing", status: "blocked" }]
-```
-
-## Floating Settings Button
-
-GDPR Article 7(3) requires consent withdrawal to be as easy as giving consent:
-
-```javascript
-floatingButton: {
-  enabled: true,
-  position: 'bottom-right',  // 'bottom-left' | 'bottom-right'
-  icon: 'cookie',            // 'cookie' | 'shield' | 'gear' | custom SVG
-  label: 'Cookie Settings',
-  showIndicator: true,
-  offset: { x: 20, y: 20 }
-}
-```
-
-**Status Indicator:**
-- 🟢 Green: All 5 categories accepted
-- 🟡 Yellow: Partial consent
-- 🔴 Red: Essential only
-
-## Global API
-
-```javascript
-window.CookieConsent.show();
-window.CookieConsent.showSettings();
-window.CookieConsent.hide();
-window.CookieConsent.getConsent();
-window.CookieConsent.isAllowed('analytics');
-window.CookieConsent.getStatus();  // 'all' | 'partial' | 'essential'
-window.CookieConsent.resetConsent();
-window.CookieConsent.scanScripts();
-window.CookieConsent.wouldRunScript(element);
-window.CookieConsent.getManagedScripts();
-window.CookieConsent.getManagedIframes();
-```
-
-## Auto-binding Elements
-
-```html
-<a href="#" data-cc-open>Manage Cookie Preferences</a>
-```
-
-## Framework Adapters
+## 🧩 Framework Adapters
 
 ### React
 
@@ -324,7 +70,7 @@ npm install cconsent cconsent-react
 ```
 
 ```tsx
-import { CookieConsentProvider, useCookieConsent, ConsentScript, ConsentGate } from 'cconsent-react';
+import { CookieConsentProvider, useCookieConsent, ConsentGate } from 'cconsent-react';
 import 'cconsent/style.css';
 
 function App() {
@@ -335,19 +81,11 @@ function App() {
   );
 }
 
-function MyComponent() {
-  const { consent, isAllowed, showSettings } = useCookieConsent();
-
+function Analytics() {
   return (
-    <>
-      <ConsentGate category="analytics" fallback={<p>Analytics disabled</p>}>
-        <AnalyticsComponent />
-      </ConsentGate>
-
-      <ConsentScript category="marketing" src="https://ads.example.com/pixel.js" />
-
-      <button onClick={showSettings}>Cookie Settings</button>
-    </>
+    <ConsentGate category="analytics" fallback={<p>Analytics disabled</p>}>
+      <AnalyticsComponent />
+    </ConsentGate>
   );
 }
 ```
@@ -359,28 +97,8 @@ npm install cconsent cconsent-vue
 ```
 
 ```typescript
-import { createApp } from 'vue';
 import { createCookieConsent } from 'cconsent-vue';
-import 'cconsent/style.css';
-
-const app = createApp(App);
 app.use(createCookieConsent({ policyUrl: '/privacy' }));
-app.mount('#app');
-```
-
-```vue
-<script setup>
-import { useCookieConsent } from 'cconsent-vue';
-
-const { consent, isAllowed, showSettings } = useCookieConsent();
-</script>
-
-<template>
-  <div v-if="isAllowed('analytics')">
-    <AnalyticsComponent />
-  </div>
-  <button @click="showSettings">Cookie Settings</button>
-</template>
 ```
 
 ### Svelte
@@ -391,124 +109,41 @@ npm install cconsent cconsent-svelte
 
 ```svelte
 <script>
+  import { initCookieConsent, consent } from 'cconsent-svelte';
   import { onMount } from 'svelte';
-  import { initCookieConsent, consent, isAllowed, showSettings } from 'cconsent-svelte';
-  import 'cconsent/style.css';
-
-  onMount(() => {
-    initCookieConsent({ policyUrl: '/privacy' });
-  });
+  
+  onMount(() => initCookieConsent({ policyUrl: '/privacy' }));
 </script>
-
-{#if $consent?.analytics}
-  <AnalyticsComponent />
-{/if}
-
-<button on:click={showSettings}>Cookie Settings</button>
 ```
 
-## Content Customization
+## 📖 Documentation
+
+For comprehensive documentation, visit the **[Wiki](../../wiki)**:
+
+- **[Getting Started](../../wiki/Getting-Started)** — Installation and basic setup
+- **[Configuration](../../wiki/Configuration)** — Full options reference
+- **[Google Consent Mode v2](../../wiki/Google-Consent-Mode-v2)** — GA4 and Ads integration
+- **[Geolocation](../../wiki/Geolocation)** — Region detection and consent modes
+- **[Script Blocking](../../wiki/Script-Blocking)** — Multi-category, negation, placeholders
+- **[Framework Adapters](../../wiki/Framework-Adapters)** — React, Vue, Svelte deep dives
+- **[API Reference](../../wiki/API-Reference)** — Methods and properties
+- **[Migration Guide](../../wiki/Migration-Guide)** — Upgrading from v1
+
+## 🔧 Global API
 
 ```javascript
-content: {
-  initialView: {
-    heading: 'Cookie settings',
-    description: {
-      text: 'We use cookies to enhance your experience. Read our ',
-      linkText: 'Cookie Policy',
-      suffix: ' to learn more.'
-    },
-    buttons: {
-      customize: 'Customize Cookie Settings',
-      rejectAll: 'Reject All Cookies',
-      acceptAll: 'Accept All Cookies'
-    }
-  },
-  settingsView: {
-    heading: 'Cookie settings',
-    description: 'Manage your preferences below.',
-    buttons: { save: 'Save Preferences' }
-  },
-  categories: {
-    necessary: 'Required for security and basic functionality.',
-    functional: 'Enables enhanced features like live chat and videos.',
-    preferences: 'Remembers your settings like language and theme.',
-    analytics: 'Helps us understand how visitors use our site.',
-    marketing: 'Enables personalized ads and tracking.'
-  }
-}
+window.CookieConsent.show();           // Show consent modal
+window.CookieConsent.showSettings();   // Open settings view
+window.CookieConsent.hide();           // Hide modal
+window.CookieConsent.getConsent();     // Get current consent state
+window.CookieConsent.isAllowed('analytics');  // Check category
+window.CookieConsent.resetConsent();   // Clear stored consent
 ```
 
-## Debug Mode
+## 🤝 Contributing
 
-```javascript
-const cookieConsent = new CookieConsent({ debug: true });
-```
+Contributions are welcome! Please read our contributing guidelines before submitting a PR.
 
-**Debug Badge Features:**
-- Shows all 5 category states
-- Lists managed scripts and iframes with status
-- Clear Consent, Randomize, and Export buttons
-- Console logging with `[cconsent]` prefix
+## 📄 License
 
-```javascript
-const state = cookieConsent.exportDebug();
-// Includes: consent, categories, scripts, iframes, geo, googleConsentMode, etc.
-```
-
-## Migration from v1
-
-If upgrading from the 3-category model (v1), consent is automatically migrated:
-
-- Existing `necessary`, `analytics`, `marketing` values are preserved
-- New `functional` and `preferences` categories default to `false`
-- Storage is updated to version `"2.0"`
-
-For backward-compatible callbacks:
-
-```javascript
-const cookieConsent = new CookieConsent({
-  legacyMode: true,  // Callbacks receive 3-category object
-  onAccept: (categories) => {
-    // categories: { necessary, analytics, marketing }
-  }
-});
-```
-
-## Accessibility
-
-- WCAG 2.1 AA compliant
-- Full keyboard navigation with focus trap
-- Screen reader support with ARIA live regions
-- High contrast mode support
-- Reduced motion support
-
-## Mobile Behavior
-
-- Bottom sheet pattern on viewports < 640px
-- Swipe-to-dismiss (rejects non-essential cookies)
-- Touch-optimized targets (48px minimum)
-- Safe area support for notched devices
-
-## Browser Support
-
-Works in all modern browsers (Chrome, Firefox, Safari, Edge).
-
-## TypeScript
-
-Full TypeScript support with exported types:
-
-```typescript
-import type {
-  CookieConsentConfig,
-  ConsentCategories,
-  ConsentState,
-  ConsentStatus,
-  GoogleConsentModeConfig,
-  GeoConfig
-} from 'cconsent';
-```
-
-## License
-
-MIT
+MIT © [Your Name]

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -62,9 +62,11 @@
 - [ ] Visual regression tests
 
 ### Documentation
-- [ ] Document inline script `type="text/plain"` requirement
-- [ ] API reference documentation
-- [ ] Migration guide from v1
+- [x] GitHub Wiki documentation structure created
+- [x] API reference documentation
+- [x] Migration guide from v1
+- [x] Framework adapter documentation (React, Vue, Svelte)
+- [x] Streamlined README.md with wiki links
 
 ### Potential Improvements
 - [ ] Convert JS implementation to TypeScript

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,477 @@
+# API Reference
+
+Complete reference for the cconsent API.
+
+## Constructor
+
+### CookieConsent(config)
+
+Creates a new CookieConsent instance.
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/privacy',
+  // ... other options
+});
+```
+
+See [Configuration](Configuration) for all available options.
+
+## Instance Methods
+
+### init()
+
+Initializes the consent manager. Must be called after creating the instance.
+
+```javascript
+const consent = new CookieConsent({ policyUrl: '/privacy' });
+consent.init();
+```
+
+**Returns:** `void`
+
+---
+
+### show()
+
+Shows the initial consent modal.
+
+```javascript
+consent.show();
+```
+
+**Returns:** `void`
+
+---
+
+### showSettings()
+
+Shows the settings/preferences view of the modal.
+
+```javascript
+consent.showSettings();
+```
+
+**Returns:** `void`
+
+---
+
+### hide()
+
+Hides the consent modal.
+
+```javascript
+consent.hide();
+```
+
+**Returns:** `void`
+
+---
+
+### getConsent()
+
+Returns the current consent state.
+
+```javascript
+const state = consent.getConsent();
+console.log(state);
+// {
+//   version: "2.0",
+//   necessary: true,
+//   functional: false,
+//   preferences: true,
+//   analytics: true,
+//   marketing: false,
+//   timestamp: "2024-01-15T10:30:00.000Z",
+//   consentId: "550e8400-e29b-41d4-a716-446655440000"  // if enabled
+// }
+```
+
+**Returns:** `ConsentState | null`
+
+---
+
+### isAllowed(category)
+
+Checks if a specific category is allowed.
+
+```javascript
+if (consent.isAllowed('analytics')) {
+  initAnalytics();
+}
+```
+
+**Parameters:**
+- `category` (string): Category name (`necessary`, `functional`, `preferences`, `analytics`, `marketing`)
+
+**Returns:** `boolean`
+
+---
+
+### getStatus()
+
+Returns the overall consent status.
+
+```javascript
+const status = consent.getStatus();
+// 'all' | 'partial' | 'essential'
+```
+
+**Returns:** `ConsentStatus`
+
+| Status | Meaning |
+|--------|---------|
+| `'all'` | All 5 categories accepted |
+| `'partial'` | Some non-essential categories accepted |
+| `'essential'` | Only necessary cookies (all others rejected) |
+
+---
+
+### resetConsent()
+
+Clears stored consent and shows the consent modal again.
+
+```javascript
+consent.resetConsent();
+```
+
+**Returns:** `void`
+
+---
+
+### scanScripts()
+
+Re-scans the DOM for elements with `data-cookie-category`.
+
+```javascript
+// After dynamically adding scripts
+consent.scanScripts();
+```
+
+**Returns:** `void`
+
+---
+
+### wouldRunScript(element)
+
+Checks if an element would be allowed to run based on current consent.
+
+```javascript
+const script = document.querySelector('[data-cookie-category="analytics"]');
+const wouldRun = consent.wouldRunScript(script);
+console.log(wouldRun); // true or false
+```
+
+**Parameters:**
+- `element` (HTMLElement): Element with `data-cookie-category` attribute
+
+**Returns:** `boolean`
+
+---
+
+### getManagedScripts()
+
+Returns an array of all scripts being managed.
+
+```javascript
+const scripts = consent.getManagedScripts();
+console.log(scripts);
+// [
+//   { src: 'https://analytics.example.com/script.js', category: 'analytics', status: 'blocked' },
+//   { src: 'inline', category: 'marketing', status: 'executed' }
+// ]
+```
+
+**Returns:** `ManagedScript[]`
+
+```typescript
+interface ManagedScript {
+  src: string;
+  category: string;
+  status: 'blocked' | 'executed';
+}
+```
+
+---
+
+### getManagedIframes()
+
+Returns an array of all iframes being managed.
+
+```javascript
+const iframes = consent.getManagedIframes();
+console.log(iframes);
+// [
+//   { src: 'https://youtube.com/embed/...', category: 'marketing', status: 'blocked' },
+//   { src: 'https://maps.google.com/...', category: 'functional', status: 'loaded' }
+// ]
+```
+
+**Returns:** `ManagedIframe[]`
+
+```typescript
+interface ManagedIframe {
+  src: string;
+  category: string;
+  status: 'blocked' | 'loaded';
+}
+```
+
+---
+
+### exportDebug()
+
+Exports the complete internal state for debugging.
+
+```javascript
+const debug = consent.exportDebug();
+console.log(debug);
+// {
+//   consent: { necessary: true, ... },
+//   config: { ... },
+//   scripts: [...],
+//   iframes: [...],
+//   geo: { country: 'DE', region: 'gdpr', mode: 'opt-in' },
+//   googleConsentMode: { ... }
+// }
+```
+
+**Returns:** `DebugExport`
+
+## Global API
+
+After initialization, a global `window.CookieConsent` object is available:
+
+```javascript
+// Access from anywhere
+window.CookieConsent.show();
+window.CookieConsent.showSettings();
+window.CookieConsent.hide();
+window.CookieConsent.getConsent();
+window.CookieConsent.isAllowed('analytics');
+window.CookieConsent.getStatus();
+window.CookieConsent.resetConsent();
+window.CookieConsent.scanScripts();
+window.CookieConsent.wouldRunScript(element);
+window.CookieConsent.getManagedScripts();
+window.CookieConsent.getManagedIframes();
+```
+
+## HTML Attributes
+
+### data-cookie-category
+
+Applied to scripts and iframes to control blocking:
+
+```html
+<script data-cookie-category="analytics" src="..."></script>
+<iframe data-cookie-category="marketing" src="..."></iframe>
+```
+
+**Values:**
+- Single category: `"analytics"`
+- Multiple categories (OR): `"analytics marketing"`
+- Negation: `"!marketing"`
+
+### data-cc-open
+
+Applied to any element to open the consent modal when clicked:
+
+```html
+<a href="#" data-cc-open>Manage Cookie Preferences</a>
+<button data-cc-open>Cookie Settings</button>
+```
+
+## Events
+
+cconsent pushes events to `window.dataLayer`:
+
+### cookie_consent_update
+
+Fired when consent changes:
+
+```javascript
+window.dataLayer.push({
+  event: 'cookie_consent_update',
+  cookie_consent: {
+    necessary: true,
+    functional: true,
+    preferences: false,
+    analytics: true,
+    marketing: false
+  }
+});
+```
+
+## Types
+
+### ConsentCategories
+
+```typescript
+interface ConsentCategories {
+  necessary: boolean;
+  functional: boolean;
+  preferences: boolean;
+  analytics: boolean;
+  marketing: boolean;
+}
+```
+
+### ConsentState
+
+```typescript
+interface ConsentState extends ConsentCategories {
+  version: string;
+  timestamp: string;
+  consentId?: string;
+}
+```
+
+### ConsentStatus
+
+```typescript
+type ConsentStatus = 'all' | 'partial' | 'essential';
+```
+
+### CookieConsentConfig
+
+```typescript
+interface CookieConsentConfig {
+  storageKey?: string;
+  storageMethod?: 'localStorage' | 'cookie';
+  cookieOptions?: CookieOptions;
+  encryption?: boolean;
+  generateConsentId?: boolean;
+  policyUrl?: string;
+  debug?: boolean;
+  legacyMode?: boolean;
+  floatingButton?: FloatingButtonConfig;
+  googleConsentMode?: GoogleConsentModeConfig;
+  geo?: GeoConfig;
+  content?: ContentConfig;
+  onAccept?: (categories: ConsentCategories) => void;
+  onReject?: (categories: ConsentCategories) => void;
+  onSave?: (categories: ConsentCategories) => void;
+}
+```
+
+### GoogleConsentModeConfig
+
+```typescript
+interface GoogleConsentModeConfig {
+  enabled: boolean;
+  waitForUpdate?: number;
+  mapping?: {
+    analytics?: string[];
+    marketing?: string[];
+    functional?: string[];
+    preferences?: string[];
+  };
+  adsDataRedaction?: boolean;
+  urlPassthrough?: boolean;
+  regionDefaults?: Record<string, Record<string, 'granted' | 'denied'>>;
+}
+```
+
+### GeoConfig
+
+```typescript
+interface GeoConfig {
+  enabled: boolean;
+  method?: 'timezone' | 'api' | 'header';
+  apiEndpoint?: string;
+  headerName?: string;
+  timeout?: number;
+  cache?: boolean;
+  cacheDuration?: number;
+  regions?: {
+    gdpr?: string[];
+    ccpa?: string[];
+    lgpd?: string[];
+    [key: string]: string[] | undefined;
+  };
+  modeByRegion?: {
+    gdpr?: 'opt-in' | 'opt-out' | 'none';
+    ccpa?: 'opt-in' | 'opt-out' | 'none';
+    lgpd?: 'opt-in' | 'opt-out' | 'none';
+    default?: 'opt-in' | 'opt-out' | 'none';
+    [key: string]: 'opt-in' | 'opt-out' | 'none' | undefined;
+  };
+}
+```
+
+### FloatingButtonConfig
+
+```typescript
+interface FloatingButtonConfig {
+  enabled: boolean;
+  position?: 'bottom-left' | 'bottom-right';
+  icon?: 'cookie' | 'shield' | 'gear' | string;
+  label?: string;
+  showIndicator?: boolean;
+  offset?: { x: number; y: number };
+}
+```
+
+## CSS Classes
+
+### Modal Classes
+
+| Class | Description |
+|-------|-------------|
+| `.cc-modal` | Main modal container |
+| `.cc-modal-overlay` | Background overlay |
+| `.cc-modal-content` | Modal content wrapper |
+| `.cc-initial-view` | Initial consent view |
+| `.cc-settings-view` | Settings/preferences view |
+
+### Button Classes
+
+| Class | Description |
+|-------|-------------|
+| `.cc-btn` | Base button class |
+| `.cc-btn-accept` | Accept all button |
+| `.cc-btn-reject` | Reject all button |
+| `.cc-btn-customize` | Customize/settings button |
+| `.cc-btn-save` | Save preferences button |
+
+### Toggle Classes
+
+| Class | Description |
+|-------|-------------|
+| `.cc-toggle` | Toggle switch container |
+| `.cc-toggle-input` | Hidden checkbox input |
+| `.cc-toggle-slider` | Visual slider element |
+
+### Other Classes
+
+| Class | Description |
+|-------|-------------|
+| `.cc-floating-btn` | Floating settings button |
+| `.cc-blocked-placeholder` | Blocked iframe placeholder |
+| `.cc-debug-badge` | Debug mode badge |
+
+## CSS Variables
+
+Customize the appearance with CSS variables:
+
+```css
+:root {
+  --cc-bg: #1a1a1a;
+  --cc-text: #ffffff;
+  --cc-text-secondary: #888888;
+  --cc-accent: #00d4aa;
+  --cc-accent-hover: #00b894;
+  --cc-border: #333333;
+  --cc-toggle-on: #00d4aa;
+  --cc-toggle-off: #555555;
+  --cc-radius: 12px;
+  --cc-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+```
+
+## Related Pages
+
+- **[Configuration](Configuration)** — Full configuration reference
+- **[Script Blocking](Script-Blocking)** — Script management details
+- **[Framework Adapters](Framework-Adapters)** — Framework-specific APIs

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,0 +1,295 @@
+# Configuration
+
+Complete reference for all cconsent configuration options.
+
+## Constructor Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `storageKey` | string | `'cookie_consent'` | Storage key name |
+| `storageMethod` | string | `'localStorage'` | `'localStorage'` or `'cookie'` |
+| `cookieOptions` | object | See below | Cookie storage configuration |
+| `encryption` | boolean | `false` | Enable Base64 encoding of consent data |
+| `generateConsentId` | boolean | `false` | Generate unique UUID for each consent |
+| `policyUrl` | string | `'#'` | URL to your cookie/privacy policy |
+| `debug` | boolean | `false` | Enable debug mode with badge and logging |
+| `legacyMode` | boolean | `false` | Use 3-category callbacks for v1 compatibility |
+| `floatingButton` | object | See below | Floating settings button configuration |
+| `googleConsentMode` | object | See below | Google Consent Mode v2 settings |
+| `geo` | object | See below | Geolocation detection settings |
+| `content` | object | See below | UI text customization |
+| `onAccept` | function | `null` | Callback when user accepts all |
+| `onReject` | function | `null` | Callback when user rejects all |
+| `onSave` | function | `null` | Callback when user saves preferences |
+
+## Storage Options
+
+### localStorage (Default)
+
+```javascript
+const consent = new CookieConsent({
+  storageMethod: 'localStorage',
+  storageKey: 'my_consent_key'
+});
+```
+
+### Cookie Storage
+
+```javascript
+const consent = new CookieConsent({
+  storageMethod: 'cookie',
+  cookieOptions: {
+    sameSite: 'Strict',  // 'Strict', 'Lax', or 'None'
+    secure: true,        // Require HTTPS
+    domain: null,        // Cookie domain (null = current domain)
+    path: '/',           // Cookie path
+    expires: 365         // Expiry in days
+  }
+});
+```
+
+> **Note**: If `sameSite: 'None'`, the `secure` option is automatically set to `true`.
+
+## Consent ID Generation
+
+Generate a unique identifier for each consent record (useful for server-side tracking):
+
+```javascript
+const consent = new CookieConsent({
+  generateConsentId: true
+});
+
+// After consent is given:
+const { consentId } = consent.getConsent();
+// consentId: "550e8400-e29b-41d4-a716-446655440000"
+```
+
+## Base64 Encoding
+
+Optionally encode consent data in Base64:
+
+```javascript
+const consent = new CookieConsent({
+  encryption: true  // Actually Base64 encoding, not encryption
+});
+```
+
+> **Note**: This is encoding, not encryption. It obfuscates data but doesn't secure it.
+
+## Floating Button
+
+GDPR Article 7(3) requires that withdrawing consent be as easy as giving it. The floating button provides this:
+
+```javascript
+const consent = new CookieConsent({
+  floatingButton: {
+    enabled: true,
+    position: 'bottom-right',  // 'bottom-left' | 'bottom-right'
+    icon: 'cookie',            // 'cookie' | 'shield' | 'gear' | custom SVG
+    label: 'Cookie Settings',  // Accessible label
+    showIndicator: true,       // Show consent status indicator
+    offset: { x: 20, y: 20 }   // Position offset in pixels
+  }
+});
+```
+
+### Status Indicator
+
+When `showIndicator: true`, the button shows a colored dot:
+
+- 🟢 **Green**: All 5 categories accepted
+- 🟡 **Yellow**: Partial consent (some categories)
+- 🔴 **Red**: Essential only (all non-necessary rejected)
+
+### Custom Icon
+
+```javascript
+floatingButton: {
+  icon: '<svg viewBox="0 0 24 24">...</svg>'
+}
+```
+
+## Content Customization
+
+Customize all UI text:
+
+```javascript
+const consent = new CookieConsent({
+  content: {
+    initialView: {
+      heading: 'Cookie settings',
+      description: {
+        text: 'We use cookies to enhance your experience. Read our ',
+        linkText: 'Cookie Policy',
+        suffix: ' to learn more.'
+      },
+      buttons: {
+        customize: 'Customize Cookie Settings',
+        rejectAll: 'Reject All Cookies',
+        acceptAll: 'Accept All Cookies'
+      }
+    },
+    settingsView: {
+      heading: 'Cookie settings',
+      description: 'Manage your preferences below.',
+      buttons: {
+        save: 'Save Preferences'
+      }
+    },
+    categories: {
+      necessary: 'Required for security and basic functionality.',
+      functional: 'Enables enhanced features like live chat and videos.',
+      preferences: 'Remembers your settings like language and theme.',
+      analytics: 'Helps us understand how visitors use our site.',
+      marketing: 'Enables personalized ads and tracking.'
+    }
+  }
+});
+```
+
+## Callbacks
+
+### Callback Signatures
+
+```javascript
+const consent = new CookieConsent({
+  onAccept: (categories) => {
+    // Called when user clicks "Accept All"
+    console.log(categories);
+    // { necessary: true, functional: true, preferences: true, 
+    //   analytics: true, marketing: true }
+  },
+  
+  onReject: (categories) => {
+    // Called when user clicks "Reject All"
+    console.log(categories);
+    // { necessary: true, functional: false, preferences: false,
+    //   analytics: false, marketing: false }
+  },
+  
+  onSave: (categories) => {
+    // Called when user clicks "Save Preferences"
+    console.log(categories);
+    // { necessary: true, functional: true, preferences: false,
+    //   analytics: true, marketing: false }
+  }
+});
+```
+
+### Legacy Mode
+
+For backward compatibility with v1 (3-category model):
+
+```javascript
+const consent = new CookieConsent({
+  legacyMode: true,
+  onAccept: (categories) => {
+    // Only receives: { necessary, analytics, marketing }
+  }
+});
+```
+
+## Debug Mode
+
+Enable comprehensive debugging:
+
+```javascript
+const consent = new CookieConsent({
+  debug: true
+});
+```
+
+### Debug Badge
+
+Shows a floating badge with:
+- Current state of all 5 categories
+- List of managed scripts with status
+- List of managed iframes with status
+- "Clear Consent" button
+- "Randomize" button (sets random consent)
+- "Export" button (copies state to clipboard)
+
+### Console Logging
+
+All actions are logged with the `[cconsent]` prefix:
+
+```
+[cconsent] Initializing with config: {...}
+[cconsent] Geo detection: GDPR region detected
+[cconsent] Script blocked: analytics.js (analytics)
+[cconsent] User accepted all categories
+```
+
+### Export Debug State
+
+```javascript
+const state = consent.exportDebug();
+console.log(state);
+// {
+//   consent: { necessary: true, ... },
+//   scripts: [{ src: '...', category: 'analytics', status: 'blocked' }],
+//   iframes: [...],
+//   geo: { region: 'EU', mode: 'opt-in' },
+//   googleConsentMode: { ... }
+// }
+```
+
+## Complete Example
+
+```javascript
+const consent = new CookieConsent({
+  // Storage
+  storageKey: 'my_site_consent',
+  storageMethod: 'cookie',
+  cookieOptions: {
+    sameSite: 'Lax',
+    secure: true,
+    expires: 365
+  },
+  
+  // Features
+  generateConsentId: true,
+  policyUrl: '/privacy-policy',
+  debug: false,
+  
+  // Floating button
+  floatingButton: {
+    enabled: true,
+    position: 'bottom-right',
+    showIndicator: true
+  },
+  
+  // Google Consent Mode
+  googleConsentMode: {
+    enabled: true,
+    waitForUpdate: 500
+  },
+  
+  // Geolocation
+  geo: {
+    enabled: true,
+    method: 'timezone'
+  },
+  
+  // Callbacks
+  onAccept: (categories) => {
+    loadAnalytics();
+    loadMarketing();
+  },
+  onReject: (categories) => {
+    // Handle rejection
+  },
+  onSave: (categories) => {
+    if (categories.analytics) loadAnalytics();
+    if (categories.marketing) loadMarketing();
+  }
+});
+
+consent.init();
+```
+
+## Related Pages
+
+- **[Google Consent Mode v2](Google-Consent-Mode-v2)** — Detailed Google integration
+- **[Geolocation](Geolocation)** — Region detection configuration
+- **[API Reference](API-Reference)** — Runtime methods and properties

--- a/wiki/Framework-Adapters.md
+++ b/wiki/Framework-Adapters.md
@@ -1,0 +1,120 @@
+# Framework Adapters
+
+cconsent provides official adapters for popular JavaScript frameworks. Each adapter wraps the core library and provides idiomatic APIs for its framework.
+
+## Available Adapters
+
+| Framework | Package | Version |
+|-----------|---------|---------|
+| React | `cconsent-react` | 2.x |
+| Vue 3 | `cconsent-vue` | 2.x |
+| Svelte | `cconsent-svelte` | 2.x |
+
+## Quick Comparison
+
+| Feature | React | Vue 3 | Svelte |
+|---------|-------|-------|--------|
+| State Management | Context API | Plugin + Composables | Stores |
+| Conditional Rendering | `<ConsentGate>` | `v-if` with `isAllowed()` | `{#if $consent}` |
+| Script Loading | `<ConsentScript>` | Manual | Manual |
+| SSR Support | ✅ | ✅ | ✅ (SvelteKit) |
+
+## Installation
+
+All adapters require the core `cconsent` package:
+
+```bash
+# React
+npm install cconsent cconsent-react
+
+# Vue 3
+npm install cconsent cconsent-vue
+
+# Svelte
+npm install cconsent cconsent-svelte
+```
+
+## Detailed Guides
+
+- **[React Adapter](React-Adapter)** — Context, hooks, and components
+- **[Vue Adapter](Vue-Adapter)** — Plugin and composables
+- **[Svelte Adapter](Svelte-Adapter)** — Stores and SvelteKit support
+
+## Common Patterns
+
+### Checking Consent
+
+All adapters provide an `isAllowed()` function:
+
+```javascript
+// React
+const { isAllowed } = useCookieConsent();
+if (isAllowed('analytics')) { ... }
+
+// Vue
+const { isAllowed } = useCookieConsent();
+if (isAllowed('analytics')) { ... }
+
+// Svelte
+import { isAllowed } from 'cconsent-svelte';
+if (isAllowed('analytics')) { ... }
+```
+
+### Opening Settings
+
+All adapters provide a `showSettings()` function:
+
+```javascript
+// React
+const { showSettings } = useCookieConsent();
+<button onClick={showSettings}>Cookie Settings</button>
+
+// Vue
+const { showSettings } = useCookieConsent();
+<button @click="showSettings">Cookie Settings</button>
+
+// Svelte
+import { showSettings } from 'cconsent-svelte';
+<button on:click={showSettings}>Cookie Settings</button>
+```
+
+### Accessing Consent State
+
+Get the current consent state:
+
+```javascript
+// React
+const { consent } = useCookieConsent();
+console.log(consent.analytics); // true/false
+
+// Vue
+const { consent } = useCookieConsent();
+console.log(consent.value.analytics);
+
+// Svelte
+import { consent } from 'cconsent-svelte';
+console.log($consent?.analytics);
+```
+
+## TypeScript Support
+
+All adapters include TypeScript definitions:
+
+```typescript
+import type { ConsentCategories, ConsentStatus } from 'cconsent';
+```
+
+## Server-Side Rendering
+
+All adapters support SSR by:
+
+1. Not rendering consent UI on server
+2. Hydrating state from stored consent on client
+3. Providing safe fallbacks during SSR
+
+## Related Pages
+
+- **[React Adapter](React-Adapter)** — Full React documentation
+- **[Vue Adapter](Vue-Adapter)** — Full Vue 3 documentation
+- **[Svelte Adapter](Svelte-Adapter)** — Full Svelte documentation
+- **[Configuration](Configuration)** — Core configuration options

--- a/wiki/Geolocation.md
+++ b/wiki/Geolocation.md
@@ -1,0 +1,343 @@
+# Geolocation
+
+cconsent can automatically detect user location and apply region-specific consent requirements. This enables proper compliance with GDPR (Europe), CCPA (California), LGPD (Brazil), and other privacy regulations.
+
+## Why Geolocation?
+
+Different regions have different consent requirements:
+
+| Region | Law | Model | Requirement |
+|--------|-----|-------|-------------|
+| EU/EEA | GDPR | Opt-in | Consent required before tracking |
+| California | CCPA | Opt-out | Can track until user opts out |
+| Brazil | LGPD | Opt-in | Consent required before tracking |
+| Other | — | None | No consent UI required |
+
+## Basic Setup
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/privacy',
+  geo: {
+    enabled: true,
+    method: 'timezone'
+  }
+});
+
+consent.init();
+```
+
+## Detection Methods
+
+### Timezone Detection (Recommended)
+
+Uses the browser's `Intl.DateTimeFormat` API to detect the user's timezone, then maps it to a country:
+
+```javascript
+geo: {
+  enabled: true,
+  method: 'timezone'
+}
+```
+
+**Pros:**
+- No external API calls
+- Works offline
+- Fast and reliable
+- GDPR-compliant (no data leaves browser)
+
+**Cons:**
+- Not 100% accurate (timezones can span multiple countries)
+- Can be spoofed by changing system timezone
+
+### API Detection
+
+Calls an external geolocation API to get the user's country:
+
+```javascript
+geo: {
+  enabled: true,
+  method: 'api',
+  apiEndpoint: 'https://api.example.com/geoip',
+  timeout: 500
+}
+```
+
+The API should return JSON with a `country` or `countryCode` field:
+
+```json
+{ "country": "DE" }
+// or
+{ "countryCode": "DE" }
+```
+
+**Pros:**
+- More accurate than timezone
+- Can detect specific regions (e.g., US-CA)
+
+**Cons:**
+- Requires external service
+- Privacy considerations (IP is sent to third party)
+- May fail or timeout
+
+### Header Detection
+
+Reads the country from HTTP headers set by your CDN/proxy:
+
+```javascript
+geo: {
+  enabled: true,
+  method: 'header',
+  headerName: 'CF-IPCountry'  // Cloudflare
+}
+```
+
+For client-side detection, the header value must be exposed via a meta tag:
+
+```html
+<!-- Set by server -->
+<meta name="user-country" content="DE">
+```
+
+Then configure:
+
+```javascript
+geo: {
+  enabled: true,
+  method: 'header'
+  // Uses <meta name="user-country"> by default
+}
+```
+
+**Pros:**
+- Very accurate (CDN-level detection)
+- No client-side API calls
+
+**Cons:**
+- Requires CDN or server-side support
+- Must expose header to client
+
+## Full Configuration
+
+```javascript
+geo: {
+  enabled: true,
+  
+  // Detection method
+  method: 'timezone',  // 'timezone' | 'api' | 'header'
+  
+  // For 'api' method
+  apiEndpoint: null,
+  timeout: 500,
+  
+  // For 'header' method
+  headerName: 'CF-IPCountry',
+  
+  // Caching
+  cache: true,
+  cacheDuration: 86400000,  // 24 hours in ms
+  
+  // Region definitions
+  regions: {
+    gdpr: [
+      'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 
+      'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 
+      'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
+      'GB', 'IS', 'LI', 'NO', 'CH'  // EEA + UK + CH
+    ],
+    ccpa: ['US-CA'],
+    lgpd: ['BR']
+  },
+  
+  // Consent mode by region
+  modeByRegion: {
+    gdpr: 'opt-in',
+    ccpa: 'opt-out',
+    lgpd: 'opt-in',
+    default: 'none'
+  }
+}
+```
+
+## Consent Modes
+
+### Opt-In Mode (GDPR)
+
+- Consent dialog shown on first visit
+- Non-essential cookies blocked by default
+- User must explicitly accept before tracking
+
+### Opt-Out Mode (CCPA)
+
+- Consent dialog shown on first visit
+- Non-essential cookies allowed by default
+- "Do Not Sell My Info" replaces "Reject All"
+- User can opt out at any time
+
+### None Mode
+
+- No consent dialog shown
+- All cookies allowed
+- For regions with no consent requirements
+
+## Region Classification
+
+cconsent maps countries to regions:
+
+```javascript
+// Built-in EU/EEA countries
+const gdprCountries = [
+  'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI',
+  'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU',
+  'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
+  'GB', 'IS', 'LI', 'NO'  // Plus UK and EEA
+];
+
+// CCPA
+const ccpaRegions = ['US-CA'];
+
+// LGPD
+const lgpdCountries = ['BR'];
+```
+
+### Custom Regions
+
+Add your own regions:
+
+```javascript
+geo: {
+  regions: {
+    gdpr: [...],  // Override or extend
+    ccpa: ['US-CA', 'US-VA', 'US-CO'],  // Add more US states
+    lgpd: ['BR'],
+    custom: ['JP', 'KR']  // Define custom region
+  },
+  modeByRegion: {
+    gdpr: 'opt-in',
+    ccpa: 'opt-out',
+    lgpd: 'opt-in',
+    custom: 'opt-in',  // Add mode for custom region
+    default: 'none'
+  }
+}
+```
+
+## Caching
+
+Geolocation results are cached to avoid repeated detection:
+
+```javascript
+geo: {
+  cache: true,
+  cacheDuration: 86400000  // 24 hours
+}
+```
+
+Cache is stored in localStorage with key `cconsent_geo`.
+
+To clear the cache:
+
+```javascript
+localStorage.removeItem('cconsent_geo');
+```
+
+## CCPA-Specific Behavior
+
+When CCPA mode is active (`modeByRegion.ccpa: 'opt-out'`):
+
+1. The reject button text changes:
+   - Default: "Reject All Cookies"
+   - CCPA: "Do Not Sell My Info"
+
+2. All non-essential categories default to accepted
+
+3. User can withdraw consent via floating button
+
+## Integration with Google Consent Mode
+
+Combine geolocation with Google Consent Mode for region-specific defaults:
+
+```javascript
+const consent = new CookieConsent({
+  geo: {
+    enabled: true,
+    method: 'timezone',
+    modeByRegion: {
+      gdpr: 'opt-in',
+      ccpa: 'opt-out',
+      default: 'none'
+    }
+  },
+  googleConsentMode: {
+    enabled: true,
+    regionDefaults: {
+      'EU': {
+        ad_storage: 'denied',
+        analytics_storage: 'denied'
+      },
+      'US': {
+        ad_storage: 'granted',
+        analytics_storage: 'granted'
+      }
+    }
+  }
+});
+```
+
+## Debugging
+
+Enable debug mode to see geolocation activity:
+
+```javascript
+const consent = new CookieConsent({
+  debug: true,
+  geo: { enabled: true }
+});
+```
+
+Console output:
+```
+[cconsent] Geo detection started: method=timezone
+[cconsent] Detected timezone: Europe/Berlin
+[cconsent] Mapped to country: DE
+[cconsent] Region: gdpr, Mode: opt-in
+```
+
+## API Reference
+
+### Getting Current Geo State
+
+```javascript
+const state = consent.exportDebug();
+console.log(state.geo);
+// {
+//   country: 'DE',
+//   region: 'gdpr',
+//   mode: 'opt-in'
+// }
+```
+
+## Common Issues
+
+### Detection Returns Wrong Country
+
+- Timezone detection can be inaccurate for border regions
+- VPN users may show different locations
+- Consider using API method for higher accuracy
+
+### CCPA Mode Not Activating
+
+- CCPA requires specific US state detection (US-CA)
+- Timezone detection only identifies country, not state
+- Use API method or header detection for state-level accuracy
+
+### Cache Showing Old Location
+
+- User may have moved or be using VPN
+- Clear cache: `localStorage.removeItem('cconsent_geo')`
+- Consider shorter `cacheDuration` for dynamic use cases
+
+## Related Pages
+
+- **[Google Consent Mode v2](Google-Consent-Mode-v2)** — Region-specific consent signals
+- **[Configuration](Configuration)** — Full configuration reference

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -20,7 +20,7 @@ yarn add cconsent
 
 ```html
 <link rel="stylesheet" href="https://unpkg.com/cconsent/dist/style.css">
-<script src="https://unpkg.com/cconsent/dist/cookie-consent.umd.js"></script>
+<script src="https://unpkg.com/cconsent/dist/index.umd.js"></script>
 ```
 
 ## Basic Setup

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,162 @@
+# Getting Started
+
+This guide will help you install cconsent and get a basic cookie consent dialog working on your site.
+
+## Installation
+
+### Option 1: NPM (Recommended)
+
+```bash
+npm install cconsent
+```
+
+### Option 2: Yarn
+
+```bash
+yarn add cconsent
+```
+
+### Option 3: CDN
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/cconsent/dist/style.css">
+<script src="https://unpkg.com/cconsent/dist/cookie-consent.umd.js"></script>
+```
+
+## Basic Setup
+
+### ES Modules
+
+```javascript
+import CookieConsent from 'cconsent';
+import 'cconsent/style.css';
+
+const consent = new CookieConsent({
+  policyUrl: '/cookie-policy'
+});
+
+consent.init();
+```
+
+### Browser (UMD)
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="css/cookie-consent.css">
+</head>
+<body>
+  <!-- Your content -->
+  
+  <script src="js/cookie-consent.js"></script>
+  <script>
+    const consent = new CookieConsent({
+      policyUrl: '/cookie-policy'
+    });
+    consent.init();
+  </script>
+</body>
+</html>
+```
+
+## Minimal Configuration
+
+The only required option is `policyUrl`:
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: 'https://yoursite.com/cookie-policy'
+});
+
+consent.init();
+```
+
+This gives you:
+- A consent modal with Accept All / Reject All / Customize buttons
+- 5-category consent management
+- localStorage persistence
+- Automatic script blocking for elements with `data-cookie-category`
+
+## Recommended Configuration
+
+For most production sites, we recommend enabling these additional features:
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/cookie-policy',
+  
+  // Enable floating settings button (GDPR requirement)
+  floatingButton: {
+    enabled: true,
+    position: 'bottom-right'
+  },
+  
+  // Enable Google Consent Mode v2
+  googleConsentMode: {
+    enabled: true
+  },
+  
+  // Enable geolocation detection
+  geo: {
+    enabled: true,
+    method: 'timezone'
+  },
+  
+  // Callbacks
+  onAccept: (categories) => {
+    console.log('User accepted:', categories);
+  },
+  onReject: (categories) => {
+    console.log('User rejected:', categories);
+  },
+  onSave: (categories) => {
+    console.log('User saved preferences:', categories);
+  }
+});
+
+consent.init();
+```
+
+## Blocking Scripts
+
+Add `data-cookie-category` to scripts and iframes that should be blocked until consent:
+
+```html
+<!-- Blocked until analytics consent -->
+<script 
+  data-cookie-category="analytics" 
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX">
+</script>
+
+<!-- Blocked until marketing consent -->
+<iframe 
+  data-cookie-category="marketing"
+  src="https://www.youtube.com/embed/VIDEO_ID">
+</iframe>
+```
+
+> **Important**: For inline scripts to be truly blocked, they should have `type="text/plain"` from the start. See [Script Blocking](Script-Blocking) for details.
+
+## Testing Your Setup
+
+Enable debug mode to see what's happening:
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/cookie-policy',
+  debug: true
+});
+```
+
+This shows:
+- A debug badge with category states
+- Console logging with `[cconsent]` prefix
+- Controls to clear, randomize, and export consent
+
+## Next Steps
+
+- **[Configuration](Configuration)** — Explore all configuration options
+- **[Google Consent Mode v2](Google-Consent-Mode-v2)** — Integrate with GA4
+- **[Script Blocking](Script-Blocking)** — Advanced blocking techniques
+- **[Framework Adapters](Framework-Adapters)** — React, Vue, Svelte integration

--- a/wiki/Google-Consent-Mode-v2.md
+++ b/wiki/Google-Consent-Mode-v2.md
@@ -1,0 +1,317 @@
+# Google Consent Mode v2
+
+cconsent provides native integration with Google Consent Mode v2, enabling proper consent signaling to Google Analytics 4 (GA4), Google Ads, and other Google services.
+
+## What is Google Consent Mode v2?
+
+Google Consent Mode v2 is an API that allows you to communicate your users' consent choices to Google services. It supports:
+
+- **analytics_storage** — Google Analytics cookies
+- **ad_storage** — Advertising cookies
+- **ad_user_data** — User data for advertising purposes
+- **ad_personalization** — Personalized advertising
+
+## Basic Setup
+
+Enable Google Consent Mode with minimal configuration:
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/privacy',
+  googleConsentMode: {
+    enabled: true
+  }
+});
+
+consent.init();
+```
+
+This will:
+1. Initialize all consent signals as `denied` on page load
+2. Update signals based on user consent choices
+3. Push events to `dataLayer` when consent changes
+
+## How It Works
+
+### Default State
+
+When the page loads, cconsent immediately sets default denied state:
+
+```javascript
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied',
+  'wait_for_update': 500
+});
+```
+
+### On Consent Update
+
+When the user makes a choice, cconsent updates the consent state:
+
+```javascript
+gtag('consent', 'update', {
+  'ad_storage': 'granted',      // if marketing accepted
+  'ad_user_data': 'granted',    // if marketing accepted
+  'ad_personalization': 'granted', // if marketing accepted
+  'analytics_storage': 'granted'   // if analytics accepted
+});
+```
+
+## Configuration Options
+
+```javascript
+const consent = new CookieConsent({
+  googleConsentMode: {
+    enabled: true,
+    
+    // Milliseconds to wait before allowing Google tags to fire
+    waitForUpdate: 500,
+    
+    // Map cconsent categories to Google consent signals
+    mapping: {
+      analytics: ['analytics_storage'],
+      marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+      functional: [],
+      preferences: []
+    },
+    
+    // Redact ad data when ad_storage is denied
+    adsDataRedaction: true,
+    
+    // Pass ad click info in URLs when ad_storage is denied
+    urlPassthrough: false,
+    
+    // Region-specific defaults
+    regionDefaults: {
+      'US': { 
+        ad_storage: 'granted', 
+        analytics_storage: 'granted' 
+      },
+      'EU': { 
+        ad_storage: 'denied', 
+        analytics_storage: 'denied' 
+      }
+    }
+  }
+});
+```
+
+## Category-to-Signal Mapping
+
+By default, cconsent maps categories to Google signals as follows:
+
+| cconsent Category | Google Signals |
+|-------------------|----------------|
+| **analytics** | `analytics_storage` |
+| **marketing** | `ad_storage`, `ad_user_data`, `ad_personalization` |
+| **functional** | (none) |
+| **preferences** | (none) |
+| **necessary** | (always granted) |
+
+### Custom Mapping
+
+You can customize this mapping:
+
+```javascript
+googleConsentMode: {
+  mapping: {
+    analytics: ['analytics_storage'],
+    marketing: ['ad_storage'],
+    functional: ['ad_user_data'],  // Move to functional
+    preferences: ['ad_personalization']  // Move to preferences
+  }
+}
+```
+
+## Ads Data Redaction
+
+When `adsDataRedaction: true` and `ad_storage` is denied, Google will:
+
+- Remove ad click identifiers from URLs
+- Redact user data in ad requests
+- Use first-party cookies with shorter lifespans
+
+```javascript
+googleConsentMode: {
+  enabled: true,
+  adsDataRedaction: true  // Recommended for GDPR
+}
+```
+
+## URL Passthrough
+
+When `urlPassthrough: true` and `ad_storage` is denied, Google will pass ad click information (gclid, dclid, etc.) through URL parameters instead of cookies:
+
+```javascript
+googleConsentMode: {
+  enabled: true,
+  urlPassthrough: true  // Enable for better conversion tracking
+}
+```
+
+This helps maintain conversion tracking without setting advertising cookies.
+
+## Region-Specific Defaults
+
+Set different default consent states based on user region:
+
+```javascript
+googleConsentMode: {
+  enabled: true,
+  regionDefaults: {
+    // EU: Default to denied (GDPR opt-in)
+    'EU': {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied'
+    },
+    
+    // US: Default to granted (opt-out model)
+    'US': {
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+      analytics_storage: 'granted'
+    },
+    
+    // California: Specific rules
+    'US-CA': {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    }
+  }
+}
+```
+
+> **Note**: Region-specific defaults require [Geolocation](Geolocation) to be enabled.
+
+## DataLayer Events
+
+When consent changes, cconsent pushes an event to `dataLayer`:
+
+```javascript
+window.dataLayer.push({
+  event: 'cookie_consent_update',
+  cookie_consent: {
+    necessary: true,
+    functional: true,
+    preferences: false,
+    analytics: true,
+    marketing: false
+  }
+});
+```
+
+You can use this event in Google Tag Manager to trigger tags based on consent.
+
+## Integration with Google Tag Manager
+
+### gtag.js Setup
+
+Make sure you load gtag.js before initializing cconsent:
+
+```html
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  
+  // Don't configure yet - cconsent will handle consent
+</script>
+
+<!-- Cookie Consent -->
+<script src="cookie-consent.js"></script>
+<script>
+  const consent = new CookieConsent({
+    policyUrl: '/privacy',
+    googleConsentMode: { enabled: true }
+  });
+  consent.init();
+  
+  // Now configure GA4
+  gtag('config', 'G-XXXXX');
+</script>
+```
+
+### Google Tag Manager Setup
+
+1. In GTM, go to **Admin → Container Settings**
+2. Enable **"Enable consent overview"**
+3. Configure your tags to require appropriate consent:
+   - GA4 tags: Require `analytics_storage`
+   - Ads tags: Require `ad_storage`
+
+cconsent will automatically signal consent state to GTM via the `dataLayer`.
+
+## Debugging
+
+Enable debug mode to see Google Consent Mode activity:
+
+```javascript
+const consent = new CookieConsent({
+  debug: true,
+  googleConsentMode: { enabled: true }
+});
+```
+
+Console output:
+```
+[cconsent] Google Consent Mode initialized: { ad_storage: 'denied', ... }
+[cconsent] Google Consent Mode updated: { ad_storage: 'granted', ... }
+```
+
+You can also check the current state:
+
+```javascript
+const state = consent.exportDebug();
+console.log(state.googleConsentMode);
+```
+
+## Common Issues
+
+### Consent Not Updating
+
+If consent signals aren't updating:
+
+1. Ensure `gtag()` function is defined before cconsent loads
+2. Check that `window.dataLayer` exists
+3. Verify `googleConsentMode.enabled` is `true`
+
+### Tags Firing Before Consent
+
+If tags fire before the user makes a choice:
+
+1. Increase `waitForUpdate` value (default: 500ms)
+2. Ensure cconsent initializes before GA4 config
+3. Check that default state is being set
+
+### Region Defaults Not Working
+
+Region-specific defaults require geolocation to be enabled:
+
+```javascript
+const consent = new CookieConsent({
+  geo: {
+    enabled: true,
+    method: 'timezone'
+  },
+  googleConsentMode: {
+    enabled: true,
+    regionDefaults: { ... }
+  }
+});
+```
+
+## Related Pages
+
+- **[Geolocation](Geolocation)** — Enable region detection
+- **[Configuration](Configuration)** — Full configuration reference
+- **[Script Blocking](Script-Blocking)** — Block Google scripts until consent

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,61 @@
+# cconsent Documentation
+
+Welcome to the cconsent wiki! This documentation covers everything you need to implement GDPR-compliant cookie consent on your website.
+
+## What is cconsent?
+
+cconsent is a lightweight, zero-dependency cookie consent library that helps you:
+
+- ✅ Comply with GDPR, CCPA, and LGPD regulations
+- ✅ Integrate with Google Consent Mode v2 for GA4 and Google Ads
+- ✅ Automatically block scripts and iframes until consent is given
+- ✅ Detect user location and apply region-specific consent modes
+- ✅ Provide a beautiful, accessible consent UI
+
+## Quick Navigation
+
+### Getting Started
+- **[Getting Started](Getting-Started)** — Installation, basic setup, and first steps
+
+### Core Features
+- **[Configuration](Configuration)** — Full reference of all configuration options
+- **[Google Consent Mode v2](Google-Consent-Mode-v2)** — Integrate with Google Analytics 4 and Google Ads
+- **[Geolocation](Geolocation)** — Auto-detect user regions and apply consent modes
+- **[Script Blocking](Script-Blocking)** — Block scripts/iframes based on consent
+
+### Framework Integration
+- **[Framework Adapters](Framework-Adapters)** — Overview of React, Vue, and Svelte support
+  - [React Adapter](React-Adapter)
+  - [Vue Adapter](Vue-Adapter)
+  - [Svelte Adapter](Svelte-Adapter)
+
+### Reference
+- **[API Reference](API-Reference)** — Complete API documentation
+- **[Migration Guide](Migration-Guide)** — Upgrading from v1 to v2
+- **[Troubleshooting](Troubleshooting)** — Common issues and solutions
+
+## Consent Categories
+
+cconsent uses a 5-category consent model:
+
+| Category | Default | Toggleable | Description |
+|----------|---------|------------|-------------|
+| **Necessary** | ON | No | Required for security and basic functionality |
+| **Functional** | OFF | Yes | Enhanced features like live chat and videos |
+| **Preferences** | OFF | Yes | Remembers settings like language and theme |
+| **Analytics** | OFF | Yes | Site usage and performance tracking |
+| **Marketing** | OFF | Yes | Personalized ads and cross-site tracking |
+
+## Browser Support
+
+cconsent works in all modern browsers:
+- Chrome 80+
+- Firefox 78+
+- Safari 14+
+- Edge 80+
+
+## Need Help?
+
+- 📖 Check the [Troubleshooting](Troubleshooting) guide
+- 🐛 Report issues on [GitHub Issues](https://github.com/your-repo/cconsent/issues)
+- 💬 Ask questions in [GitHub Discussions](https://github.com/your-repo/cconsent/discussions)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -57,5 +57,5 @@ cconsent works in all modern browsers:
 ## Need Help?
 
 - 📖 Check the [Troubleshooting](Troubleshooting) guide
-- 🐛 Report issues on [GitHub Issues](https://github.com/your-repo/cconsent/issues)
-- 💬 Ask questions in [GitHub Discussions](https://github.com/your-repo/cconsent/discussions)
+- 🐛 Report issues on [GitHub Issues](https://github.com/pxdsgnco/cconsent/issues)
+- 💬 Ask questions in [GitHub Discussions](https://github.com/pxdsgnco/cconsent/discussions)

--- a/wiki/Migration-Guide.md
+++ b/wiki/Migration-Guide.md
@@ -311,7 +311,7 @@ If you need to rollback to v1:
 
 - Check the [Troubleshooting](Troubleshooting) page
 - Review the [API Reference](API-Reference)
-- Open an issue on [GitHub](https://github.com/your-repo/cconsent/issues)
+- Open an issue on [GitHub](https://github.com/pxdsgnco/cconsent/issues)
 
 ## Related Pages
 

--- a/wiki/Migration-Guide.md
+++ b/wiki/Migration-Guide.md
@@ -1,0 +1,320 @@
+# Migration Guide
+
+This guide helps you upgrade from cconsent v1 (3-category model) to v2 (5-category model).
+
+## What's New in v2
+
+### 5-Category Model
+
+v1 had 3 categories:
+- Necessary
+- Analytics
+- Marketing
+
+v2 adds 2 new categories:
+- **Functional** — Enhanced features like live chat, video embeds
+- **Preferences** — User settings like language, theme
+
+### Automatic Migration
+
+cconsent automatically migrates stored consent from v1 to v2:
+
+| v1 Value | v2 Value |
+|----------|----------|
+| `necessary: true` | `necessary: true` |
+| `analytics: true/false` | `analytics: true/false` (preserved) |
+| `marketing: true/false` | `marketing: true/false` (preserved) |
+| — | `functional: false` (new, defaults to off) |
+| — | `preferences: false` (new, defaults to off) |
+
+The storage version is updated from `"1.0"` to `"2.0"`.
+
+## Breaking Changes
+
+### Consent Object Shape
+
+**v1:**
+```javascript
+{
+  version: "1.0",
+  necessary: true,
+  analytics: boolean,
+  marketing: boolean,
+  timestamp: string
+}
+```
+
+**v2:**
+```javascript
+{
+  version: "2.0",
+  necessary: true,
+  functional: boolean,   // NEW
+  preferences: boolean,  // NEW
+  analytics: boolean,
+  marketing: boolean,
+  timestamp: string,
+  consentId?: string     // NEW (if enabled)
+}
+```
+
+### Callback Parameters
+
+Callbacks now receive 5 categories instead of 3:
+
+**v1:**
+```javascript
+onAccept: (categories) => {
+  // categories: { necessary, analytics, marketing }
+}
+```
+
+**v2:**
+```javascript
+onAccept: (categories) => {
+  // categories: { necessary, functional, preferences, analytics, marketing }
+}
+```
+
+## Using Legacy Mode
+
+If you need backward-compatible callbacks temporarily, enable legacy mode:
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/privacy',
+  legacyMode: true,
+  
+  onAccept: (categories) => {
+    // Still receives 3-category object:
+    // { necessary, analytics, marketing }
+  }
+});
+```
+
+> **Note:** Legacy mode only affects callback parameters. The stored consent and UI still use the 5-category model.
+
+## Migration Checklist
+
+### 1. Update Callbacks
+
+If you process consent in callbacks, update them to handle new categories:
+
+**Before:**
+```javascript
+onSave: (categories) => {
+  if (categories.analytics) enableAnalytics();
+  if (categories.marketing) enableMarketing();
+}
+```
+
+**After:**
+```javascript
+onSave: (categories) => {
+  if (categories.functional) enableFunctional();
+  if (categories.preferences) enablePreferences();
+  if (categories.analytics) enableAnalytics();
+  if (categories.marketing) enableMarketing();
+}
+```
+
+### 2. Update Script Categories
+
+Review your blocked scripts and assign appropriate categories:
+
+**Scripts that might be "Functional":**
+- Chat widgets (Intercom, Zendesk)
+- Video embeds (YouTube, Vimeo)
+- Payment processors
+- Social share buttons
+
+**Scripts that might be "Preferences":**
+- Language/locale detection
+- Theme/dark mode persistence
+- Accessibility settings
+
+```html
+<!-- Before: lumped into marketing -->
+<script data-cookie-category="marketing" src="https://chat.example.com/widget.js"></script>
+
+<!-- After: properly categorized -->
+<script data-cookie-category="functional" src="https://chat.example.com/widget.js"></script>
+```
+
+### 3. Update isAllowed() Checks
+
+If you check consent programmatically, add checks for new categories:
+
+```javascript
+// Add checks for new categories
+if (consent.isAllowed('functional')) {
+  loadChatWidget();
+}
+
+if (consent.isAllowed('preferences')) {
+  loadLanguageDetection();
+}
+```
+
+### 4. Update Server-Side Processing
+
+If you store consent server-side, update your schema:
+
+**Before:**
+```sql
+CREATE TABLE consent (
+  id UUID PRIMARY KEY,
+  necessary BOOLEAN,
+  analytics BOOLEAN,
+  marketing BOOLEAN,
+  timestamp TIMESTAMP
+);
+```
+
+**After:**
+```sql
+CREATE TABLE consent (
+  id UUID PRIMARY KEY,
+  necessary BOOLEAN,
+  functional BOOLEAN,    -- NEW
+  preferences BOOLEAN,   -- NEW
+  analytics BOOLEAN,
+  marketing BOOLEAN,
+  timestamp TIMESTAMP,
+  consent_id UUID        -- NEW (if using generateConsentId)
+);
+```
+
+### 5. Update Analytics Events
+
+If you track consent in analytics, add new events:
+
+```javascript
+onSave: (categories) => {
+  gtag('event', 'consent_update', {
+    functional: categories.functional,
+    preferences: categories.preferences,
+    analytics: categories.analytics,
+    marketing: categories.marketing
+  });
+}
+```
+
+## New Features to Consider
+
+### Generate Consent IDs
+
+Track consent records with unique IDs:
+
+```javascript
+const consent = new CookieConsent({
+  generateConsentId: true
+});
+
+// Access the ID
+const { consentId } = consent.getConsent();
+// "550e8400-e29b-41d4-a716-446655440000"
+```
+
+### Google Consent Mode v2
+
+New in v2, native Google Consent Mode integration:
+
+```javascript
+const consent = new CookieConsent({
+  googleConsentMode: {
+    enabled: true,
+    adsDataRedaction: true,
+    urlPassthrough: true
+  }
+});
+```
+
+### Geolocation Detection
+
+Automatically detect user region and apply appropriate consent mode:
+
+```javascript
+const consent = new CookieConsent({
+  geo: {
+    enabled: true,
+    method: 'timezone',
+    modeByRegion: {
+      gdpr: 'opt-in',
+      ccpa: 'opt-out'
+    }
+  }
+});
+```
+
+### Floating Settings Button
+
+GDPR-compliant settings button:
+
+```javascript
+const consent = new CookieConsent({
+  floatingButton: {
+    enabled: true,
+    position: 'bottom-right',
+    showIndicator: true
+  }
+});
+```
+
+## Gradual Migration
+
+If you can't update everything at once:
+
+### Phase 1: Enable v2 with Legacy Mode
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/privacy',
+  legacyMode: true  // Callbacks still receive 3 categories
+});
+```
+
+### Phase 2: Update Callbacks
+
+```javascript
+const consent = new CookieConsent({
+  policyUrl: '/privacy',
+  legacyMode: false,  // Now receives 5 categories
+  
+  onSave: (categories) => {
+    // Handle all 5 categories
+  }
+});
+```
+
+### Phase 3: Categorize Scripts
+
+Update your `data-cookie-category` attributes to use `functional` and `preferences` where appropriate.
+
+### Phase 4: Enable New Features
+
+Add Google Consent Mode, geolocation, floating button, etc.
+
+## Rollback
+
+If you need to rollback to v1:
+
+1. Install the previous version:
+   ```bash
+   npm install cconsent@1.x
+   ```
+
+2. Existing v2 consent will be ignored (version mismatch)
+3. Users will be prompted for consent again
+
+## Getting Help
+
+- Check the [Troubleshooting](Troubleshooting) page
+- Review the [API Reference](API-Reference)
+- Open an issue on [GitHub](https://github.com/your-repo/cconsent/issues)
+
+## Related Pages
+
+- **[Configuration](Configuration)** — Full options reference
+- **[Getting Started](Getting-Started)** — Fresh installation guide
+- **[API Reference](API-Reference)** — Complete API documentation

--- a/wiki/React-Adapter.md
+++ b/wiki/React-Adapter.md
@@ -1,0 +1,332 @@
+# React Adapter
+
+The `cconsent-react` package provides React-specific components and hooks for managing cookie consent.
+
+## Installation
+
+```bash
+npm install cconsent cconsent-react
+```
+
+## Setup
+
+Wrap your app with `CookieConsentProvider`:
+
+```tsx
+import { CookieConsentProvider } from 'cconsent-react';
+import 'cconsent/style.css';
+
+function App() {
+  return (
+    <CookieConsentProvider config={{
+      policyUrl: '/privacy',
+      googleConsentMode: { enabled: true },
+      floatingButton: { enabled: true }
+    }}>
+      <YourApp />
+    </CookieConsentProvider>
+  );
+}
+```
+
+## Provider Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `config` | `CookieConsentConfig` | Core cconsent configuration |
+| `children` | `ReactNode` | Child components |
+
+The `config` prop accepts all options documented in [Configuration](Configuration).
+
+## Hooks
+
+### useCookieConsent
+
+Access consent state and methods:
+
+```tsx
+import { useCookieConsent } from 'cconsent-react';
+
+function MyComponent() {
+  const {
+    consent,        // Current consent state
+    status,         // 'all' | 'partial' | 'essential'
+    isAllowed,      // (category: string) => boolean
+    show,           // () => void - Show initial modal
+    showSettings,   // () => void - Show settings view
+    hide,           // () => void - Hide modal
+    resetConsent,   // () => void - Clear stored consent
+    instance        // CookieConsent instance
+  } = useCookieConsent();
+
+  return (
+    <div>
+      <p>Analytics allowed: {isAllowed('analytics') ? 'Yes' : 'No'}</p>
+      <button onClick={showSettings}>Cookie Settings</button>
+    </div>
+  );
+}
+```
+
+### Hook Return Values
+
+| Value | Type | Description |
+|-------|------|-------------|
+| `consent` | `ConsentCategories \| null` | Current consent state or null |
+| `status` | `ConsentStatus` | Overall consent status |
+| `isAllowed` | `(category: string) => boolean` | Check if category is allowed |
+| `show` | `() => void` | Show consent modal |
+| `showSettings` | `() => void` | Show settings view |
+| `hide` | `() => void` | Hide modal |
+| `resetConsent` | `() => void` | Clear and reset consent |
+| `instance` | `CookieConsent` | Raw cconsent instance |
+
+## Components
+
+### ConsentGate
+
+Conditionally render content based on consent:
+
+```tsx
+import { ConsentGate } from 'cconsent-react';
+
+function Analytics() {
+  return (
+    <ConsentGate 
+      category="analytics" 
+      fallback={<p>Analytics tracking is disabled.</p>}
+    >
+      <AnalyticsComponent />
+    </ConsentGate>
+  );
+}
+```
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `category` | `string` | required | Consent category to check |
+| `fallback` | `ReactNode` | `null` | Content to show when not allowed |
+| `children` | `ReactNode` | required | Content to show when allowed |
+
+### ConsentScript
+
+Load external scripts conditionally:
+
+```tsx
+import { ConsentScript } from 'cconsent-react';
+
+function Tracking() {
+  return (
+    <>
+      <ConsentScript
+        category="analytics"
+        src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX"
+        onLoad={() => console.log('Analytics loaded')}
+      />
+      
+      <ConsentScript
+        category="marketing"
+        src="https://connect.facebook.net/en_US/fbevents.js"
+        async
+        defer
+      />
+    </>
+  );
+}
+```
+
+#### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `category` | `string` | required | Consent category required |
+| `src` | `string` | required | Script URL |
+| `onLoad` | `() => void` | - | Callback when loaded |
+| `onError` | `(error: Error) => void` | - | Callback on error |
+| `async` | `boolean` | `true` | Async attribute |
+| `defer` | `boolean` | `false` | Defer attribute |
+
+## Patterns
+
+### Analytics Integration
+
+```tsx
+import { useCookieConsent, ConsentGate, ConsentScript } from 'cconsent-react';
+
+function AnalyticsWrapper() {
+  const { consent, isAllowed } = useCookieConsent();
+
+  // Effect that runs when analytics consent is granted
+  useEffect(() => {
+    if (isAllowed('analytics')) {
+      // Initialize analytics
+      gtag('config', 'G-XXXXX');
+    }
+  }, [consent?.analytics, isAllowed]);
+
+  return (
+    <ConsentGate category="analytics">
+      <ConsentScript
+        category="analytics"
+        src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX"
+      />
+    </ConsentGate>
+  );
+}
+```
+
+### Cookie Settings Link
+
+```tsx
+function Footer() {
+  const { showSettings } = useCookieConsent();
+
+  return (
+    <footer>
+      <button onClick={showSettings}>
+        Manage Cookie Preferences
+      </button>
+    </footer>
+  );
+}
+```
+
+### Consent Status Display
+
+```tsx
+function ConsentBadge() {
+  const { status } = useCookieConsent();
+
+  const colors = {
+    all: 'green',
+    partial: 'yellow',
+    essential: 'red'
+  };
+
+  return (
+    <span style={{ color: colors[status] }}>
+      Consent: {status}
+    </span>
+  );
+}
+```
+
+### Marketing Pixels
+
+```tsx
+function MarketingPixels() {
+  const { isAllowed } = useCookieConsent();
+
+  if (!isAllowed('marketing')) {
+    return null;
+  }
+
+  return (
+    <>
+      <ConsentScript 
+        category="marketing" 
+        src="https://connect.facebook.net/en_US/fbevents.js" 
+      />
+      <ConsentScript 
+        category="marketing" 
+        src="https://www.googleadservices.com/pagead/conversion_async.js" 
+      />
+    </>
+  );
+}
+```
+
+## TypeScript
+
+The adapter is fully typed:
+
+```tsx
+import type { 
+  CookieConsentConfig, 
+  ConsentCategories, 
+  ConsentStatus 
+} from 'cconsent';
+
+interface MyConsentProps {
+  config: CookieConsentConfig;
+}
+
+function MyConsent({ config }: MyConsentProps) {
+  return (
+    <CookieConsentProvider config={config}>
+      <App />
+    </CookieConsentProvider>
+  );
+}
+```
+
+## Server-Side Rendering
+
+The adapter handles SSR gracefully:
+
+- Provider renders children immediately
+- Consent state is `null` until hydration
+- Modal only renders on client
+
+```tsx
+function SSRSafeComponent() {
+  const { consent, isAllowed } = useCookieConsent();
+
+  // consent is null during SSR
+  if (consent === null) {
+    return <p>Loading consent...</p>;
+  }
+
+  return (
+    <div>
+      Analytics: {isAllowed('analytics') ? 'Enabled' : 'Disabled'}
+    </div>
+  );
+}
+```
+
+## Next.js Integration
+
+For Next.js, use the `'use client'` directive:
+
+```tsx
+// components/CookieConsent.tsx
+'use client';
+
+import { CookieConsentProvider } from 'cconsent-react';
+import 'cconsent/style.css';
+
+export function CookieConsent({ children }: { children: React.ReactNode }) {
+  return (
+    <CookieConsentProvider config={{ policyUrl: '/privacy' }}>
+      {children}
+    </CookieConsentProvider>
+  );
+}
+```
+
+```tsx
+// app/layout.tsx
+import { CookieConsent } from '@/components/CookieConsent';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <CookieConsent>
+          {children}
+        </CookieConsent>
+      </body>
+    </html>
+  );
+}
+```
+
+## Related Pages
+
+- **[Framework Adapters](Framework-Adapters)** — Overview
+- **[Vue Adapter](Vue-Adapter)** — Vue 3 documentation
+- **[Svelte Adapter](Svelte-Adapter)** — Svelte documentation
+- **[Configuration](Configuration)** — Core options

--- a/wiki/Script-Blocking.md
+++ b/wiki/Script-Blocking.md
@@ -1,0 +1,350 @@
+# Script Blocking
+
+cconsent can automatically block scripts and iframes until the user grants consent for the appropriate category. This is essential for GDPR compliance, where tracking scripts should not execute before consent.
+
+## How It Works
+
+1. **Initial Scan**: On initialization, cconsent scans the DOM for elements with `data-cookie-category`
+2. **Blocking**: Scripts are converted to `type="text/plain"`, iframes have their `src` replaced
+3. **Observation**: MutationObserver watches for dynamically added elements
+4. **Unblocking**: When consent is granted, scripts execute and iframes load
+
+## Basic Usage
+
+Add `data-cookie-category` to any script or iframe:
+
+```html
+<!-- Blocked until analytics consent -->
+<script 
+  data-cookie-category="analytics" 
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX">
+</script>
+
+<!-- Blocked until marketing consent -->
+<iframe 
+  data-cookie-category="marketing"
+  src="https://www.youtube.com/embed/VIDEO_ID">
+</iframe>
+```
+
+## Inline Scripts
+
+For inline scripts, you **must** add `type="text/plain"` from the start:
+
+```html
+<!-- ✅ Correct: Will be blocked -->
+<script type="text/plain" data-cookie-category="analytics">
+  console.log('This runs only after analytics consent');
+  gtag('event', 'page_view');
+</script>
+
+<!-- ❌ Wrong: Will execute immediately, then cconsent tries to block (too late!) -->
+<script data-cookie-category="analytics">
+  console.log('This runs immediately!');
+</script>
+```
+
+> **Why?** The browser executes inline scripts immediately when parsing HTML. By the time cconsent scans the DOM, the script has already run. Using `type="text/plain"` prevents execution.
+
+## Categories
+
+Use any of the 5 consent categories:
+
+| Category | Attribute Value |
+|----------|-----------------|
+| Necessary | `necessary` (always allowed) |
+| Functional | `functional` |
+| Preferences | `preferences` |
+| Analytics | `analytics` |
+| Marketing | `marketing` |
+
+## Multi-Category Support
+
+### OR Logic (Any Category)
+
+Scripts can require any of multiple categories (OR logic):
+
+```html
+<!-- Loads if EITHER analytics OR marketing is consented -->
+<script 
+  data-cookie-category="analytics marketing" 
+  src="https://example.com/combo-script.js">
+</script>
+```
+
+### Negation
+
+Block scripts when a category is **not** consented:
+
+```html
+<!-- Loads only if marketing is NOT consented -->
+<script 
+  data-cookie-category="!marketing" 
+  src="https://privacy-focused-analytics.com/script.js">
+</script>
+```
+
+### Complex Rules
+
+Combine multiple conditions:
+
+```html
+<!-- Loads if (analytics OR marketing) AND NOT preferences -->
+<script data-cookie-category="analytics marketing !preferences" src="..."></script>
+```
+
+## Blocked Iframe Placeholders
+
+When an iframe is blocked, cconsent displays a placeholder:
+
+```html
+<!-- Original -->
+<iframe 
+  data-cookie-category="marketing" 
+  src="https://youtube.com/embed/VIDEO_ID"
+  width="560" 
+  height="315">
+</iframe>
+
+<!-- Becomes (when blocked) -->
+<div class="cc-blocked-placeholder" style="width: 560px; height: 315px;">
+  <p>This content is blocked because you haven't accepted marketing cookies.</p>
+  <a href="#" data-cc-open>Change settings</a>
+</div>
+```
+
+### Styling Placeholders
+
+```css
+.cc-blocked-placeholder {
+  background: #1a1a1a;
+  border: 1px dashed #444;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  text-align: center;
+  color: #888;
+}
+
+.cc-blocked-placeholder a {
+  color: #00d4aa;
+  margin-top: 10px;
+}
+```
+
+## Dynamic Script Detection
+
+cconsent uses MutationObserver to detect scripts and iframes added dynamically:
+
+```javascript
+// This script will be automatically blocked
+const script = document.createElement('script');
+script.src = 'https://analytics.example.com/track.js';
+script.setAttribute('data-cookie-category', 'analytics');
+document.body.appendChild(script);
+
+// Later, when analytics consent is granted, it will execute
+```
+
+## Script Management API
+
+### Re-scan DOM
+
+Force a re-scan for new scripts/iframes:
+
+```javascript
+window.CookieConsent.scanScripts();
+```
+
+### Check Element Status
+
+Check if an element would be allowed to run:
+
+```javascript
+const element = document.querySelector('[data-cookie-category="analytics"]');
+const wouldRun = window.CookieConsent.wouldRunScript(element);
+console.log(wouldRun); // true or false
+```
+
+### Get Managed Scripts
+
+List all scripts being managed:
+
+```javascript
+const scripts = window.CookieConsent.getManagedScripts();
+console.log(scripts);
+// [
+//   { src: 'https://analytics.example.com/script.js', category: 'analytics', status: 'blocked' },
+//   { src: 'https://cdn.example.com/lib.js', category: 'functional', status: 'executed' }
+// ]
+```
+
+### Get Managed Iframes
+
+List all iframes being managed:
+
+```javascript
+const iframes = window.CookieConsent.getManagedIframes();
+console.log(iframes);
+// [
+//   { src: 'https://youtube.com/embed/...', category: 'marketing', status: 'blocked' },
+//   { src: 'https://maps.google.com/...', category: 'functional', status: 'loaded' }
+// ]
+```
+
+## Integration with Tag Managers
+
+### Google Tag Manager
+
+For GTM, use Google Consent Mode instead of direct blocking:
+
+```javascript
+const consent = new CookieConsent({
+  googleConsentMode: { enabled: true }
+});
+```
+
+GTM will respect the consent signals automatically.
+
+### Other Tag Managers
+
+For other tag managers, block the main script:
+
+```html
+<script 
+  type="text/plain" 
+  data-cookie-category="analytics marketing"
+  src="https://other-tag-manager.com/script.js">
+</script>
+```
+
+## Best Practices
+
+### 1. Always Use `type="text/plain"` for Inline Scripts
+
+```html
+<!-- ✅ Correct -->
+<script type="text/plain" data-cookie-category="analytics">
+  trackPageView();
+</script>
+```
+
+### 2. Place cconsent Before Other Scripts
+
+```html
+<head>
+  <!-- Load cconsent first -->
+  <link rel="stylesheet" href="cookie-consent.css">
+  <script src="cookie-consent.js"></script>
+  
+  <!-- Then other scripts (they'll be caught by the scanner) -->
+  <script data-cookie-category="analytics" src="analytics.js"></script>
+</head>
+```
+
+### 3. Use Appropriate Categories
+
+| Script Type | Recommended Category |
+|-------------|---------------------|
+| Google Analytics | `analytics` |
+| Google Ads | `marketing` |
+| Facebook Pixel | `marketing` |
+| YouTube Embeds | `marketing` or `functional` |
+| Chat Widgets | `functional` |
+| Language Detection | `preferences` |
+| A/B Testing | `analytics` or `functional` |
+
+### 4. Test in Debug Mode
+
+```javascript
+const consent = new CookieConsent({
+  debug: true
+});
+```
+
+This shows all managed scripts and their status in the debug badge.
+
+## Common Issues
+
+### Script Still Executes Before Consent
+
+**Cause**: Inline script without `type="text/plain"`
+
+**Solution**:
+```html
+<!-- Add type="text/plain" -->
+<script type="text/plain" data-cookie-category="analytics">
+  // ...
+</script>
+```
+
+### External Script Loads but Doesn't Execute
+
+**Cause**: Script loaded but inline callback not blocked
+
+**Solution**: Block both the external script and its callback:
+```html
+<script data-cookie-category="analytics" src="https://analytics.js"></script>
+<script type="text/plain" data-cookie-category="analytics">
+  initAnalytics();
+</script>
+```
+
+### Dynamically Added Scripts Not Blocked
+
+**Cause**: Script added without `data-cookie-category`
+
+**Solution**: Always add the attribute:
+```javascript
+const script = document.createElement('script');
+script.setAttribute('data-cookie-category', 'analytics');
+script.src = 'https://analytics.example.com/script.js';
+document.body.appendChild(script);
+```
+
+### Iframe Placeholder Sizing Wrong
+
+**Cause**: Original iframe dimensions not preserved
+
+**Solution**: Explicitly set width/height on the iframe:
+```html
+<iframe 
+  data-cookie-category="marketing"
+  src="https://youtube.com/embed/..."
+  width="560"
+  height="315">
+</iframe>
+```
+
+## Debugging
+
+### Debug Badge
+
+In debug mode, the badge shows:
+- List of all managed scripts
+- List of all managed iframes
+- Status of each (blocked/executed/loaded)
+
+### Console Logging
+
+```
+[cconsent] Script blocked: https://analytics.example.com/script.js (analytics)
+[cconsent] Iframe blocked: https://youtube.com/embed/... (marketing)
+[cconsent] Script executed: https://analytics.example.com/script.js (analytics consent granted)
+```
+
+### Export Script State
+
+```javascript
+const state = consent.exportDebug();
+console.log(state.scripts);
+console.log(state.iframes);
+```
+
+## Related Pages
+
+- **[Getting Started](Getting-Started)** — Initial setup
+- **[Configuration](Configuration)** — All options
+- **[Google Consent Mode v2](Google-Consent-Mode-v2)** — Alternative for Google scripts

--- a/wiki/Svelte-Adapter.md
+++ b/wiki/Svelte-Adapter.md
@@ -1,0 +1,405 @@
+# Svelte Adapter
+
+The `cconsent-svelte` package provides Svelte-specific integration with stores, context, and SvelteKit support.
+
+## Installation
+
+```bash
+npm install cconsent cconsent-svelte
+```
+
+## Setup
+
+Initialize in your root component or layout:
+
+```svelte
+<!-- +layout.svelte or App.svelte -->
+<script>
+  import { onMount } from 'svelte';
+  import { initCookieConsent } from 'cconsent-svelte';
+  import 'cconsent/style.css';
+
+  onMount(() => {
+    initCookieConsent({
+      policyUrl: '/privacy',
+      googleConsentMode: { enabled: true },
+      floatingButton: { enabled: true }
+    });
+  });
+</script>
+
+<slot />
+```
+
+## Stores
+
+The adapter provides reactive Svelte stores:
+
+```svelte
+<script>
+  import { consent, status, instance } from 'cconsent-svelte';
+  
+  // $consent - ConsentCategories | null
+  // $status - ConsentStatus
+  // $instance - CookieConsent instance
+</script>
+
+<p>Analytics: {$consent?.analytics ? 'Enabled' : 'Disabled'}</p>
+<p>Status: {$status}</p>
+```
+
+### Available Stores
+
+| Store | Type | Description |
+|-------|------|-------------|
+| `consent` | `Readable<ConsentCategories \| null>` | Current consent state |
+| `status` | `Readable<ConsentStatus>` | Overall consent status |
+| `instance` | `Readable<CookieConsent \| null>` | Raw cconsent instance |
+
+## Functions
+
+### isAllowed
+
+Check if a category is allowed:
+
+```svelte
+<script>
+  import { isAllowed } from 'cconsent-svelte';
+</script>
+
+{#if isAllowed('analytics')}
+  <AnalyticsComponent />
+{:else}
+  <p>Analytics disabled</p>
+{/if}
+```
+
+### showSettings / show / hide
+
+Control the consent modal:
+
+```svelte
+<script>
+  import { showSettings, show, hide } from 'cconsent-svelte';
+</script>
+
+<button on:click={showSettings}>Cookie Settings</button>
+<button on:click={show}>Show Consent</button>
+<button on:click={hide}>Hide Modal</button>
+```
+
+### resetConsent
+
+Clear stored consent:
+
+```svelte
+<script>
+  import { resetConsent } from 'cconsent-svelte';
+</script>
+
+<button on:click={resetConsent}>Reset Cookie Preferences</button>
+```
+
+## Patterns
+
+### Conditional Rendering
+
+```svelte
+<script>
+  import { consent, showSettings } from 'cconsent-svelte';
+</script>
+
+{#if $consent?.analytics}
+  <AnalyticsComponent />
+{:else}
+  <div class="consent-placeholder">
+    <p>Analytics tracking is disabled.</p>
+    <button on:click={showSettings}>Enable Analytics</button>
+  </div>
+{/if}
+```
+
+### ConsentGate Component
+
+Create a reusable gate component:
+
+```svelte
+<!-- ConsentGate.svelte -->
+<script>
+  import { consent, showSettings } from 'cconsent-svelte';
+  
+  export let category;
+  export let fallbackText = `This content requires ${category} cookies.`;
+  
+  $: allowed = $consent?.[category] ?? false;
+</script>
+
+{#if allowed}
+  <slot />
+{:else}
+  <slot name="fallback">
+    <div class="consent-gate-fallback">
+      <p>{fallbackText}</p>
+      <button on:click={showSettings}>Change Settings</button>
+    </div>
+  </slot>
+{/if}
+```
+
+Usage:
+
+```svelte
+<ConsentGate category="marketing">
+  <YouTubeEmbed videoId="..." />
+  
+  <svelte:fragment slot="fallback">
+    <p>Video blocked. Please accept marketing cookies.</p>
+  </svelte:fragment>
+</ConsentGate>
+```
+
+### Watch Consent Changes
+
+```svelte
+<script>
+  import { consent } from 'cconsent-svelte';
+  
+  $: if ($consent?.analytics) {
+    // Analytics consent just became true
+    initializeAnalytics();
+  }
+  
+  // Or with reactive statement
+  $: analyticsEnabled = $consent?.analytics ?? false;
+  $: {
+    if (analyticsEnabled) {
+      console.log('Analytics enabled!');
+    }
+  }
+</script>
+```
+
+### Dynamic Script Loading
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  import { consent } from 'cconsent-svelte';
+  
+  let scriptLoaded = false;
+  
+  $: if ($consent?.analytics && !scriptLoaded) {
+    loadAnalyticsScript();
+  }
+  
+  function loadAnalyticsScript() {
+    const script = document.createElement('script');
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=G-XXXXX';
+    script.async = true;
+    script.onload = () => {
+      scriptLoaded = true;
+      window.gtag('config', 'G-XXXXX');
+    };
+    document.head.appendChild(script);
+  }
+</script>
+```
+
+### ConsentScript Component
+
+Create a component for consent-aware script loading:
+
+```svelte
+<!-- ConsentScript.svelte -->
+<script>
+  import { consent } from 'cconsent-svelte';
+  import { onMount } from 'svelte';
+  
+  export let category;
+  export let src;
+  export let async = true;
+  
+  let loaded = false;
+  
+  $: if ($consent?.[category] && !loaded) {
+    loadScript();
+  }
+  
+  function loadScript() {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = async;
+    script.onload = () => {
+      loaded = true;
+      dispatch('load');
+    };
+    document.head.appendChild(script);
+  }
+</script>
+```
+
+Usage:
+
+```svelte
+<ConsentScript 
+  category="analytics" 
+  src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX"
+  on:load={() => console.log('Loaded!')}
+/>
+```
+
+### Consent Status Badge
+
+```svelte
+<script>
+  import { status } from 'cconsent-svelte';
+  
+  const statusLabels = {
+    all: 'All Accepted',
+    partial: 'Partial',
+    essential: 'Essential Only'
+  };
+</script>
+
+<span class="status-badge status-{$status}">
+  {statusLabels[$status]}
+</span>
+
+<style>
+  .status-badge {
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+  .status-all { background: #22c55e; color: white; }
+  .status-partial { background: #eab308; color: black; }
+  .status-essential { background: #ef4444; color: white; }
+</style>
+```
+
+## Context API
+
+For components that need access without importing stores:
+
+```svelte
+<!-- Parent.svelte -->
+<script>
+  import { setContext } from 'svelte';
+  import { consent, showSettings } from 'cconsent-svelte';
+  
+  setContext('cookieConsent', { consent, showSettings });
+</script>
+
+<Child />
+```
+
+```svelte
+<!-- Child.svelte -->
+<script>
+  import { getContext } from 'svelte';
+  
+  const { consent, showSettings } = getContext('cookieConsent');
+</script>
+
+{#if $consent?.marketing}
+  <MarketingWidget />
+{/if}
+```
+
+## TypeScript
+
+The adapter includes full TypeScript support:
+
+```typescript
+// +layout.svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { initCookieConsent, consent, status } from 'cconsent-svelte';
+  import type { CookieConsentConfig } from 'cconsent';
+  import 'cconsent/style.css';
+
+  const config: CookieConsentConfig = {
+    policyUrl: '/privacy',
+    googleConsentMode: { enabled: true }
+  };
+
+  onMount(() => {
+    initCookieConsent(config);
+  });
+</script>
+```
+
+## SvelteKit Integration
+
+### Layout Setup
+
+```svelte
+<!-- src/routes/+layout.svelte -->
+<script>
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { initCookieConsent } from 'cconsent-svelte';
+  import 'cconsent/style.css';
+
+  onMount(() => {
+    if (browser) {
+      initCookieConsent({
+        policyUrl: '/privacy'
+      });
+    }
+  });
+</script>
+
+<slot />
+```
+
+### Server-Side Rendering
+
+The adapter handles SSR gracefully:
+
+- `initCookieConsent` only runs on client
+- Stores return `null` during SSR
+- Use `{#if $consent}` to prevent hydration mismatches
+
+```svelte
+<script>
+  import { consent } from 'cconsent-svelte';
+</script>
+
+{#if $consent}
+  <!-- Only renders after hydration -->
+  {#if $consent.analytics}
+    <AnalyticsComponent />
+  {/if}
+{:else}
+  <p>Loading...</p>
+{/if}
+```
+
+### Page-Specific Consent Checks
+
+```svelte
+<!-- src/routes/analytics/+page.svelte -->
+<script>
+  import { consent, showSettings } from 'cconsent-svelte';
+  import { goto } from '$app/navigation';
+  
+  $: if ($consent && !$consent.analytics) {
+    // Redirect if analytics not consented
+    goto('/');
+  }
+</script>
+
+{#if $consent?.analytics}
+  <AnalyticsDashboard />
+{:else}
+  <p>Please accept analytics cookies to view this page.</p>
+  <button on:click={showSettings}>Cookie Settings</button>
+{/if}
+```
+
+## Related Pages
+
+- **[Framework Adapters](Framework-Adapters)** — Overview
+- **[React Adapter](React-Adapter)** — React documentation
+- **[Vue Adapter](Vue-Adapter)** — Vue 3 documentation
+- **[Configuration](Configuration)** — Core options

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -435,7 +435,7 @@ console.log(JSON.stringify(state, null, 2));
 If you can't solve your issue:
 
 1. **Check debug output** with `debug: true`
-2. **Search existing issues** on [GitHub](https://github.com/your-repo/cconsent/issues)
+2. **Search existing issues** on [GitHub](https://github.com/pxdsgnco/cconsent/issues)
 3. **Open a new issue** with:
    - cconsent version
    - Browser and version

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,450 @@
+# Troubleshooting
+
+Common issues and solutions when using cconsent.
+
+## Installation Issues
+
+### Module Not Found
+
+**Error:**
+```
+Cannot find module 'cconsent' or its corresponding type declarations
+```
+
+**Solutions:**
+1. Install the package:
+   ```bash
+   npm install cconsent
+   ```
+
+2. Check your import path:
+   ```javascript
+   // Correct
+   import CookieConsent from 'cconsent';
+   
+   // Wrong
+   import CookieConsent from 'cconsent/dist/index';
+   ```
+
+3. For TypeScript, ensure `moduleResolution` is set correctly:
+   ```json
+   {
+     "compilerOptions": {
+       "moduleResolution": "node"
+     }
+   }
+   ```
+
+### CSS Not Loading
+
+**Issue:** Modal appears unstyled or invisible.
+
+**Solutions:**
+1. Import the CSS:
+   ```javascript
+   import 'cconsent/style.css';
+   ```
+
+2. Or link it in HTML:
+   ```html
+   <link rel="stylesheet" href="https://unpkg.com/cconsent/dist/style.css">
+   ```
+
+3. Check for CSS conflicts:
+   ```css
+   /* Your styles might override cconsent */
+   .cc-modal { display: block !important; }
+   ```
+
+---
+
+## Consent Modal Issues
+
+### Modal Doesn't Show
+
+**Possible causes:**
+
+1. **Consent already stored:**
+   ```javascript
+   // Check if consent exists
+   console.log(localStorage.getItem('cookie_consent'));
+   
+   // Clear to test
+   localStorage.removeItem('cookie_consent');
+   ```
+
+2. **init() not called:**
+   ```javascript
+   const consent = new CookieConsent({ policyUrl: '/privacy' });
+   consent.init();  // Don't forget this!
+   ```
+
+3. **Geolocation mode is "none":**
+   ```javascript
+   // If user is in a region with modeByRegion: 'none', no modal shows
+   geo: {
+     enabled: true,
+     modeByRegion: {
+       default: 'opt-in'  // Change from 'none' to show modal everywhere
+     }
+   }
+   ```
+
+### Modal Shows on Every Page Load
+
+**Cause:** Consent not being saved properly.
+
+**Solutions:**
+1. Check storage method:
+   ```javascript
+   // localStorage (default)
+   console.log(localStorage.getItem('cookie_consent'));
+   
+   // or cookie storage
+   console.log(document.cookie);
+   ```
+
+2. Ensure no code is calling `resetConsent()` on load.
+
+3. Check for storage quota errors in console.
+
+### Modal Flashes Then Disappears
+
+**Cause:** Geolocation detecting a "none" mode region.
+
+**Solution:**
+```javascript
+geo: {
+  enabled: true,
+  modeByRegion: {
+    gdpr: 'opt-in',
+    ccpa: 'opt-out',
+    default: 'opt-in'  // Don't use 'none' if you always want a modal
+  }
+}
+```
+
+---
+
+## Script Blocking Issues
+
+### Script Executes Before Consent
+
+**Cause:** Inline script without `type="text/plain"`.
+
+**Wrong:**
+```html
+<script data-cookie-category="analytics">
+  // This executes immediately!
+  trackPageView();
+</script>
+```
+
+**Correct:**
+```html
+<script type="text/plain" data-cookie-category="analytics">
+  // Now this is blocked until consent
+  trackPageView();
+</script>
+```
+
+### Script Never Executes After Consent
+
+**Possible causes:**
+
+1. **Script not re-scanned:**
+   ```javascript
+   // Force re-scan
+   window.CookieConsent.scanScripts();
+   ```
+
+2. **Category mismatch:**
+   ```html
+   <!-- Make sure category matches what user consented to -->
+   <script data-cookie-category="analytics">  <!-- not "analytic" -->
+   ```
+
+3. **Script error after loading:**
+   ```javascript
+   // Check console for errors after consent
+   // The script might load but fail to execute due to other issues
+   ```
+
+### Dynamically Added Scripts Not Blocked
+
+**Cause:** Script added without `data-cookie-category`.
+
+**Solution:**
+```javascript
+const script = document.createElement('script');
+script.setAttribute('data-cookie-category', 'analytics');  // Add this!
+script.src = 'https://analytics.example.com/script.js';
+document.body.appendChild(script);
+```
+
+---
+
+## Google Consent Mode Issues
+
+### gtag Not Defined
+
+**Error:**
+```
+ReferenceError: gtag is not defined
+```
+
+**Solution:** Load gtag.js before cconsent:
+```html
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+</script>
+
+<!-- Then cconsent -->
+<script src="cookie-consent.js"></script>
+```
+
+### Consent Not Updating in Google
+
+**Solutions:**
+
+1. Ensure Google Consent Mode is enabled:
+   ```javascript
+   googleConsentMode: {
+     enabled: true  // Must be true
+   }
+   ```
+
+2. Check dataLayer events:
+   ```javascript
+   // After consent
+   console.log(window.dataLayer);
+   // Should see gtag consent update events
+   ```
+
+3. Verify in Google Tag Assistant or Analytics debugger.
+
+### Region Defaults Not Working
+
+**Cause:** Geolocation not enabled.
+
+**Solution:**
+```javascript
+const consent = new CookieConsent({
+  geo: {
+    enabled: true,  // Required for regionDefaults
+    method: 'timezone'
+  },
+  googleConsentMode: {
+    enabled: true,
+    regionDefaults: {
+      'EU': { ad_storage: 'denied' }
+    }
+  }
+});
+```
+
+---
+
+## Geolocation Issues
+
+### Wrong Country Detected
+
+**Cause:** Timezone detection is approximate.
+
+**Solutions:**
+
+1. Use API detection for better accuracy:
+   ```javascript
+   geo: {
+     method: 'api',
+     apiEndpoint: 'https://your-geoip-api.com/json'
+   }
+   ```
+
+2. Or use CDN headers:
+   ```javascript
+   geo: {
+     method: 'header',
+     headerName: 'CF-IPCountry'  // Cloudflare
+   }
+   ```
+
+### CCPA Mode Not Activating
+
+**Cause:** State-level detection required but using timezone.
+
+**Solution:** Timezone only detects country. For US states, use API:
+```javascript
+geo: {
+  method: 'api',
+  apiEndpoint: 'https://api.example.com/geoip',
+  regions: {
+    ccpa: ['US-CA', 'US-VA', 'US-CO']
+  }
+}
+```
+
+### Geolocation Cache Stale
+
+**Solution:**
+```javascript
+// Clear cache
+localStorage.removeItem('cconsent_geo');
+
+// Or disable caching
+geo: {
+  enabled: true,
+  cache: false
+}
+```
+
+---
+
+## Framework Adapter Issues
+
+### React: useCookieConsent Returns Undefined
+
+**Cause:** Component not wrapped in provider.
+
+**Solution:**
+```tsx
+// App.tsx
+<CookieConsentProvider config={{ policyUrl: '/privacy' }}>
+  <YourApp />  {/* useCookieConsent works here */}
+</CookieConsentProvider>
+```
+
+### Vue: composable not working
+
+**Cause:** Plugin not registered.
+
+**Solution:**
+```typescript
+// main.ts
+import { createCookieConsent } from 'cconsent-vue';
+
+app.use(createCookieConsent({ policyUrl: '/privacy' }));
+```
+
+### Svelte: Stores are null
+
+**Cause:** `initCookieConsent` not called.
+
+**Solution:**
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  import { initCookieConsent } from 'cconsent-svelte';
+
+  onMount(() => {
+    initCookieConsent({ policyUrl: '/privacy' });
+  });
+</script>
+```
+
+### SSR Hydration Mismatch
+
+**Cause:** Consent state differs between server and client.
+
+**Solution:** Wrap consent-dependent UI:
+```jsx
+// React
+{consent !== null && (
+  <div>Analytics: {isAllowed('analytics') ? 'Yes' : 'No'}</div>
+)}
+```
+
+```vue
+<!-- Vue -->
+<div v-if="consent">
+  Analytics: {{ isAllowed('analytics') ? 'Yes' : 'No' }}
+</div>
+```
+
+---
+
+## Styling Issues
+
+### Modal Behind Other Elements
+
+**Solution:**
+```css
+.cc-modal-overlay {
+  z-index: 99999 !important;
+}
+```
+
+### Mobile Bottom Sheet Not Working
+
+**Cause:** Viewport meta tag missing.
+
+**Solution:**
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
+
+### Dark/Light Theme Conflict
+
+**Solution:** Override CSS variables:
+```css
+/* Force dark theme */
+.cc-modal {
+  --cc-bg: #1a1a1a;
+  --cc-text: #ffffff;
+}
+
+/* Force light theme */
+.cc-modal {
+  --cc-bg: #ffffff;
+  --cc-text: #1a1a1a;
+}
+```
+
+---
+
+## Debug Mode
+
+Enable debug mode to diagnose issues:
+
+```javascript
+const consent = new CookieConsent({
+  debug: true,
+  policyUrl: '/privacy'
+});
+```
+
+This provides:
+- Console logging with `[cconsent]` prefix
+- Debug badge showing all states
+- Export function for state inspection
+
+### Export Debug State
+
+```javascript
+const state = consent.exportDebug();
+console.log(JSON.stringify(state, null, 2));
+```
+
+---
+
+## Getting Help
+
+If you can't solve your issue:
+
+1. **Check debug output** with `debug: true`
+2. **Search existing issues** on [GitHub](https://github.com/your-repo/cconsent/issues)
+3. **Open a new issue** with:
+   - cconsent version
+   - Browser and version
+   - Minimal reproduction code
+   - Debug export output
+
+## Related Pages
+
+- **[Configuration](Configuration)** — Check your config options
+- **[API Reference](API-Reference)** — Verify method usage
+- **[Script Blocking](Script-Blocking)** — Script blocking details
+- **[Migration Guide](Migration-Guide)** — v1 to v2 changes

--- a/wiki/Vue-Adapter.md
+++ b/wiki/Vue-Adapter.md
@@ -1,0 +1,322 @@
+# Vue Adapter
+
+The `cconsent-vue` package provides Vue 3-specific integration with plugin architecture and composables.
+
+## Installation
+
+```bash
+npm install cconsent cconsent-vue
+```
+
+## Setup
+
+Register the plugin in your Vue app:
+
+```typescript
+import { createApp } from 'vue';
+import { createCookieConsent } from 'cconsent-vue';
+import 'cconsent/style.css';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(createCookieConsent({
+  policyUrl: '/privacy',
+  googleConsentMode: { enabled: true },
+  floatingButton: { enabled: true }
+}));
+
+app.mount('#app');
+```
+
+## Plugin Options
+
+The plugin accepts all options documented in [Configuration](Configuration).
+
+## Composables
+
+### useCookieConsent
+
+Access consent state and methods in any component:
+
+```vue
+<script setup>
+import { useCookieConsent } from 'cconsent-vue';
+
+const {
+  consent,        // Ref<ConsentCategories | null>
+  status,         // Ref<ConsentStatus>
+  isAllowed,      // (category: string) => boolean
+  show,           // () => void
+  showSettings,   // () => void
+  hide,           // () => void
+  resetConsent,   // () => void
+  instance        // CookieConsent instance
+} = useCookieConsent();
+</script>
+
+<template>
+  <div>
+    <p>Analytics: {{ isAllowed('analytics') ? 'Enabled' : 'Disabled' }}</p>
+    <button @click="showSettings">Cookie Settings</button>
+  </div>
+</template>
+```
+
+### Return Values
+
+| Value | Type | Description |
+|-------|------|-------------|
+| `consent` | `Ref<ConsentCategories \| null>` | Reactive consent state |
+| `status` | `Ref<ConsentStatus>` | Overall consent status |
+| `isAllowed` | `(category: string) => boolean` | Check if category is allowed |
+| `show` | `() => void` | Show consent modal |
+| `showSettings` | `() => void` | Show settings view |
+| `hide` | `() => void` | Hide modal |
+| `resetConsent` | `() => void` | Clear and reset consent |
+| `instance` | `CookieConsent` | Raw cconsent instance |
+
+## Global Property
+
+The cconsent instance is available as a global property:
+
+```vue
+<script>
+export default {
+  mounted() {
+    // Access via Options API
+    this.$cookieConsent.showSettings();
+    console.log(this.$cookieConsent.getConsent());
+  }
+}
+</script>
+```
+
+## Patterns
+
+### Conditional Rendering
+
+Use `v-if` with `isAllowed()`:
+
+```vue
+<script setup>
+import { useCookieConsent } from 'cconsent-vue';
+
+const { isAllowed } = useCookieConsent();
+</script>
+
+<template>
+  <div v-if="isAllowed('analytics')">
+    <AnalyticsComponent />
+  </div>
+  <div v-else>
+    <p>Analytics is disabled. 
+      <a href="#" @click.prevent="showSettings">Enable it</a>
+    </p>
+  </div>
+</template>
+```
+
+### ConsentGate Component
+
+Create a reusable gate component:
+
+```vue
+<!-- components/ConsentGate.vue -->
+<script setup>
+import { useCookieConsent } from 'cconsent-vue';
+
+const props = defineProps({
+  category: {
+    type: String,
+    required: true
+  }
+});
+
+const { isAllowed, showSettings } = useCookieConsent();
+</script>
+
+<template>
+  <slot v-if="isAllowed(category)" />
+  <slot v-else name="fallback">
+    <p>This content requires {{ category }} cookies.</p>
+    <button @click="showSettings">Change Settings</button>
+  </slot>
+</template>
+```
+
+Usage:
+
+```vue
+<ConsentGate category="marketing">
+  <YouTubeEmbed videoId="..." />
+  
+  <template #fallback>
+    <p>Video unavailable. Please accept marketing cookies.</p>
+  </template>
+</ConsentGate>
+```
+
+### Watch Consent Changes
+
+```vue
+<script setup>
+import { watch } from 'vue';
+import { useCookieConsent } from 'cconsent-vue';
+
+const { consent, isAllowed } = useCookieConsent();
+
+// Watch for analytics consent changes
+watch(
+  () => consent.value?.analytics,
+  (newValue, oldValue) => {
+    if (newValue && !oldValue) {
+      // Analytics just got enabled
+      initializeAnalytics();
+    }
+  }
+);
+</script>
+```
+
+### Dynamic Script Loading
+
+```vue
+<script setup>
+import { watchEffect, ref } from 'vue';
+import { useCookieConsent } from 'cconsent-vue';
+
+const { isAllowed } = useCookieConsent();
+const analyticsLoaded = ref(false);
+
+watchEffect(() => {
+  if (isAllowed('analytics') && !analyticsLoaded.value) {
+    const script = document.createElement('script');
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=G-XXXXX';
+    script.async = true;
+    script.onload = () => {
+      analyticsLoaded.value = true;
+      gtag('config', 'G-XXXXX');
+    };
+    document.head.appendChild(script);
+  }
+});
+</script>
+```
+
+### Footer Settings Link
+
+```vue
+<script setup>
+import { useCookieConsent } from 'cconsent-vue';
+
+const { showSettings } = useCookieConsent();
+</script>
+
+<template>
+  <footer>
+    <nav>
+      <a href="/privacy">Privacy Policy</a>
+      <a href="#" @click.prevent="showSettings">Cookie Settings</a>
+    </nav>
+  </footer>
+</template>
+```
+
+### Consent Status Badge
+
+```vue
+<script setup>
+import { computed } from 'vue';
+import { useCookieConsent } from 'cconsent-vue';
+
+const { status } = useCookieConsent();
+
+const statusConfig = {
+  all: { color: 'green', label: 'All Accepted' },
+  partial: { color: 'yellow', label: 'Partial Consent' },
+  essential: { color: 'red', label: 'Essential Only' }
+};
+
+const currentStatus = computed(() => statusConfig[status.value]);
+</script>
+
+<template>
+  <span :class="`status-${status}`">
+    {{ currentStatus.label }}
+  </span>
+</template>
+
+<style scoped>
+.status-all { color: green; }
+.status-partial { color: orange; }
+.status-essential { color: red; }
+</style>
+```
+
+## TypeScript
+
+The adapter includes full TypeScript support:
+
+```typescript
+import { createCookieConsent, useCookieConsent } from 'cconsent-vue';
+import type { CookieConsentConfig } from 'cconsent';
+
+const config: CookieConsentConfig = {
+  policyUrl: '/privacy',
+  googleConsentMode: { enabled: true }
+};
+
+app.use(createCookieConsent(config));
+```
+
+## Nuxt 3 Integration
+
+Create a plugin for Nuxt 3:
+
+```typescript
+// plugins/cookie-consent.client.ts
+import { createCookieConsent } from 'cconsent-vue';
+import 'cconsent/style.css';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(createCookieConsent({
+    policyUrl: '/privacy'
+  }));
+});
+```
+
+Note the `.client.ts` suffix to ensure client-only execution.
+
+## Server-Side Rendering
+
+The adapter handles SSR gracefully:
+
+- Plugin skips initialization on server
+- `consent` ref is `null` until hydration
+- Use `v-if="consent"` to prevent SSR mismatches
+
+```vue
+<script setup>
+import { useCookieConsent } from 'cconsent-vue';
+
+const { consent, isAllowed } = useCookieConsent();
+</script>
+
+<template>
+  <!-- Safe for SSR -->
+  <div v-if="consent">
+    <p v-if="isAllowed('analytics')">Analytics enabled</p>
+  </div>
+  <div v-else>
+    Loading...
+  </div>
+</template>
+```
+
+## Related Pages
+
+- **[Framework Adapters](Framework-Adapters)** — Overview
+- **[React Adapter](React-Adapter)** — React documentation
+- **[Svelte Adapter](Svelte-Adapter)** — Svelte documentation
+- **[Configuration](Configuration)** — Core options

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,27 @@
+**[🏠 Home](Home)**
+
+---
+
+### Getting Started
+- [Installation & Setup](Getting-Started)
+- [Configuration](Configuration)
+
+### Core Features
+- [Google Consent Mode v2](Google-Consent-Mode-v2)
+- [Geolocation](Geolocation)
+- [Script Blocking](Script-Blocking)
+
+### Framework Adapters
+- [Overview](Framework-Adapters)
+- [React](React-Adapter)
+- [Vue 3](Vue-Adapter)
+- [Svelte](Svelte-Adapter)
+
+### Reference
+- [API Reference](API-Reference)
+- [Migration Guide](Migration-Guide)
+- [Troubleshooting](Troubleshooting)
+
+---
+
+**[📦 npm](https://www.npmjs.com/package/cconsent)** · **[🐙 GitHub](https://github.com/your-repo/cconsent)**

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -24,4 +24,4 @@
 
 ---
 
-**[📦 npm](https://www.npmjs.com/package/cconsent)** · **[🐙 GitHub](https://github.com/your-repo/cconsent)**
+**[📦 npm](https://www.npmjs.com/package/cconsent)** · **[🐙 GitHub](https://github.com/pxdsgnco/cconsent)**


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the cconsent library, reorganized to use GitHub wiki.

### Changes

**README.md**
- Streamlined from ~500 lines to ~130 lines
- Focused on quick start and essential features
- Added links to wiki for detailed documentation

**Wiki Documentation (14 files)**
| File | Content |
|------|---------|
| `Home.md` | Overview and navigation |
| `Getting-Started.md` | Installation and basic setup |
| `Configuration.md` | Full options reference |
| `Google-Consent-Mode-v2.md` | GA4/Ads integration deep dive |
| `Geolocation.md` | Region detection and consent modes |
| `Script-Blocking.md` | Multi-category blocking, placeholders |
| `Framework-Adapters.md` | Overview of all adapters |
| `React-Adapter.md` | Provider, hooks, components |
| `Vue-Adapter.md` | Plugin, composables |
| `Svelte-Adapter.md` | Stores, SvelteKit support |
| `API-Reference.md` | Complete API documentation |
| `Migration-Guide.md` | v1 → v2 upgrade guide |
| `Troubleshooting.md` | Common issues and solutions |
| `_Sidebar.md` | Wiki navigation sidebar |

### Next Steps After Merge

1. Enable wiki on GitHub (Settings → Features → Wiki)
2. Push wiki content to the wiki repo:
   ```bash
   git clone https://github.com/pxdsgnco/cconsent.wiki.git
   cp wiki/*.md cconsent.wiki/
   cd cconsent.wiki && git add . && git commit -m 'Add documentation' && git push
   ```